### PR TITLE
[Android] [Bug] Fix  - Unordered list followed by ordered list not working correclty

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/RendererUtil.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/RendererUtil.java
@@ -208,6 +208,12 @@ public class RendererUtil
         {
             boolean tagWasHandled = false;
 
+            if ((tag.equals("ol") && !opening))
+            {
+                orderedList = false;
+                tagWasHandled = true;
+            }
+
             if (tag.equals("ul") && !opening)
             {
                 output.append("\n");


### PR DESCRIPTION

# Description

If a text contains unordered list followed by ordered list, the bullet point is not showing and replaced with numbers.

# Sample Card

```
                {
			"type": "TextBlock",
			"text": "1. Numbered\r- List\r",
			"wrap": true
		}
```

# How Verified
verified with the card

Before             |  After
:-------------------------:|:-------------------------:
![screenshot-1724048798505](https://github.com/user-attachments/assets/dc55894c-b9ba-4ee2-9901-9f23c8c58ad3) |  ![screenshot-1724048757508](https://github.com/user-attachments/assets/3c5ead20-59fc-4b44-b0dc-e3ef23a8038f)



