### PR TITLE
[Compound Button] Fix Border Width

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
@@ -90,7 +90,7 @@
     
     UIView *compoundButtonView = [[UIView alloc] initWithFrame:CGRectZero];
     compoundButtonView.translatesAutoresizingMaskIntoConstraints = NO;
-    compoundButtonView.layer.borderWidth = 0.5;
+    compoundButtonView.layer.borderWidth = 1;
     std::string compoundButtonViewBorderColor = config->GetCompoundButtonConfig().borderColor;
     compoundButtonView.layer.borderColor = [ACOHostConfig convertHexColorCodeToUIColor:compoundButtonViewBorderColor].CGColor;
     compoundButtonView.layer.cornerRadius = 12;


### PR DESCRIPTION
# Related Issue
As based on the recent discussion and design changes, the border width of compound button should be 1px same as android
<img src="https://github.com/user-attachments/assets/0a37b54a-623d-4013-ac64-4b57039a0f2c"  height="600"/>

