### PR TITLE
fix: sanitize unescaped problematic url regex strings

### DIFF
--- a/samples/v1.4/Tests/Action.Execute.With.RegexValidation.json
+++ b/samples/v1.4/Tests/Action.Execute.With.RegexValidation.json
@@ -1,0 +1,85 @@
+{
+	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+	"type": "AdaptiveCard",
+	"version": "1.4",
+	"body": [
+		{
+			"type": "TextBlock",
+			"text": "Present a form and submit it back to the originator (with validation!)"
+		},
+		{
+			"type": "ActionSet",
+			"actions": [
+				{
+					"type": "Action.Execute",
+					"title": "ActionSet Execute",
+					"verb": "doActionSetStuff",
+					"iconUrl": "https://adaptivecards.io/content/Closed%20bug%2092x92.png",
+					"associatedInputs": "none",
+					"data": {
+						"y": -1
+					}
+				},
+				{
+					"type": "Action.ShowCard",
+					"title": "ShowCard",
+					"card": {
+						"type": "AdaptiveCard",
+						"actions": [
+							{
+								"type": "Action.Execute",
+								"title": "Neat!",
+								"associatedInputs": "none"
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"type": "Input.Text",
+			"id": "firstRegexCase",
+			"isRequired": true,
+            "regex": "^([a-zA-Z0-9._%+-]+@outokumpu\.com)(,[a-zA-Z0-9._%+-]+@outokumpu\.com)*$",
+			"label": "What is your first regex case?"
+		},
+        {
+            "type": "Input.Text",
+            "id": "secondRegexCase",
+            "regex": "^([a-zA-Z0-9._%+-]+@outokumpu\\.com)(,[a-zA-Z0-9._%+-]+@outokumpu\\.com)*$",
+            "label": "What is your second regex case?"
+        },
+        {
+            "type": "Input.Text",
+            "id": "thirdRegexCase",
+            "isRequired": true,
+            "regex": "^([a-zA-Z0-9._%+-]+@outokumpu\\\.com)(,[a-zA-Z0-9._%+-]+@outokumpu\\\.com)*$",
+            "label": "What is your third regex case?"
+        },
+        {
+            "type": "Input.Text",
+            "id": "fourthRegexCase",
+            "isRequired": true,
+            "regex": "^([a-zA-Z0-9._%+-]+@outokumpu\\\\.com)(,[a-zA-Z0-9._%+-]+@outokumpu\\\\.com)*$",
+            "label": "What is your fourth regex case?"
+        },
+        {
+            "type": "Input.Text",
+            "id": "fifthRegexCase",
+            "isRequired": true,
+            "regex": "^([a-zA-Z0-9._%+-]+@outokumpu\\\\\.com)(,[a-zA-Z0-9._%+-]+@outokumpu\\\\\.com)*$",
+            "label": "What is your fifth regex case?"
+        }
+	],
+	"actions": [
+		{
+			"type": "Action.Execute",
+			"title": "Action.Execute",
+			"verb": "doStuff",
+			"iconUrl": "https://adaptivecards.io/content/Closed%20bug%2092x92.png",
+			"data": {
+				"x": 13
+			}
+		}
+	]
+}

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
@@ -63,7 +63,8 @@ using namespace AdaptiveCards;
     if (payload) {
         try {
             ACOAdaptiveCard *card = [[ACOAdaptiveCard alloc] init];
-            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(std::string([payload UTF8String]), g_version);
+            NSString *processedPayload = [payload stringByReplacingOccurrencesOfString:@"\\." withString:@"\\\\."];
+            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(std::string([processedPayload UTF8String]), g_version);
             NSMutableArray *acrParseWarnings = [[NSMutableArray alloc] init];
             std::vector<std::shared_ptr<AdaptiveCardParseWarning>> parseWarnings = parseResult->GetWarnings();
             for (const auto &warning : parseWarnings) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
@@ -93,80 +93,55 @@ using namespace AdaptiveCards;
     return (*error == nil);
 }
 
-
 + (ACOAdaptiveCardParseResult *)fromJson:(NSString *)payload {
     const std::string g_version = "1.6";
     ACOAdaptiveCardParseResult *result = nil;
+
     if (payload) {
         NSError *jsonError = nil;
 
         // First, check if the JSON is valid
         if (![self isValidJson:payload error:&jsonError]) {
             NSLog(@"Initial JSON Deserialization Error: %@", jsonError.localizedDescription);
-            jsonError = nil;
-
             // Attempt to fix the JSON using regex replacement
             NSString *processedPayload = [self correctInvalidJsonEscapes:payload];
-
-            // Check if the corrected JSON is valid
-            if (![self isValidJson:processedPayload error:&jsonError]) {
-                NSLog(@"JSON Deserialization Error after fix: %@", jsonError.localizedDescription);
-                return result; // Return nil result if JSON is still invalid
-            }
-
             // Update payload to the corrected version
             payload = processedPayload;
         }
 
-        // If JSON is valid or fixed, convert to NSData
-        NSData *jsonData = [payload dataUsingEncoding:NSUTF8StringEncoding];
-
-        // Deserialize JSON data to NSDictionary/NSArray
-        id jsonObject = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&jsonError];
-
-        if (jsonObject != nil) {
-            // Re-serialize the object to JSON data
-            jsonData = [NSJSONSerialization dataWithJSONObject:jsonObject options:0 error:&jsonError];
-            if (jsonError == nil && jsonData != nil) {
-                // Convert back to NSString
-                NSString *escapedPayload = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-                
-                try {
-                    ACOAdaptiveCard *card = [[ACOAdaptiveCard alloc] init];
-                    std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(std::string([escapedPayload UTF8String]), g_version);
-                    NSMutableArray *acrParseWarnings = [[NSMutableArray alloc] init];
-                    std::vector<std::shared_ptr<AdaptiveCardParseWarning>> parseWarnings = parseResult->GetWarnings();
-                    for (const auto &warning : parseWarnings) {
-                        ACRParseWarning *acrParseWarning = [[ACRParseWarning alloc] initWithParseWarning:warning];
-                        [acrParseWarnings addObject:acrParseWarning];
-                    }
-                    card->_adaptiveCard = parseResult->GetAdaptiveCard();
-                    if (card && card->_adaptiveCard) {
-                        card->_refresh = [[ACORefresh alloc] init:card->_adaptiveCard->GetRefresh()];
-                        card->_authentication = [[ACOAuthentication alloc] init:card->_adaptiveCard->GetAuthentication()];
-                    }
-                    result = [[ACOAdaptiveCardParseResult alloc] init:card errors:nil warnings:acrParseWarnings];
-                } catch (const AdaptiveCardParseException &e) {
-                    // Converts AdaptiveCardParseException to NSError
-                    ErrorStatusCode errorStatusCode = e.GetStatusCode();
-                    NSInteger errorCode = (long)errorStatusCode;
-                    NSBundle *adaptiveCardsBundle = [[ACOBundle getInstance] getBundle];
-                    NSString *localizedFormat = NSLocalizedStringFromTableInBundle(@"AdaptiveCards.Parsing", nil, adaptiveCardsBundle, "Parsing Error Messages");
-                    NSString *objectModelErrorCodeInString = [NSString stringWithCString:ErrorStatusCodeToString(errorStatusCode).c_str() encoding:NSUTF8StringEncoding];
-                    NSDictionary<NSErrorUserInfoKey, id> *userInfo = @{NSLocalizedDescriptionKey : [NSString localizedStringWithFormat:localizedFormat, objectModelErrorCodeInString]};
-                    NSError *parseError = [NSError errorWithDomain:ACRParseErrorDomain
-                                                              code:errorCode
-                                                          userInfo:userInfo];
-                    NSArray<NSError *> *errors = @[ parseError ];
-
-                    result = [[ACOAdaptiveCardParseResult alloc] init:nil errors:errors warnings:nil];
-                }
-            } else {
-                // Handle JSON serialization error
-                NSLog(@"JSON Serialization Error: %@", jsonError.localizedDescription);
+        // Use the already validated JSON object without re-serialization
+        try {
+            ACOAdaptiveCard *card = [[ACOAdaptiveCard alloc] init];
+            std::shared_ptr<ParseResult> parseResult = AdaptiveCard::DeserializeFromString(std::string([payload UTF8String]), g_version);
+            NSMutableArray *acrParseWarnings = [[NSMutableArray alloc] init];
+            std::vector<std::shared_ptr<AdaptiveCardParseWarning>> parseWarnings = parseResult->GetWarnings();
+            for (const auto &warning : parseWarnings) {
+                ACRParseWarning *acrParseWarning = [[ACRParseWarning alloc] initWithParseWarning:warning];
+                [acrParseWarnings addObject:acrParseWarning];
             }
+            card->_adaptiveCard = parseResult->GetAdaptiveCard();
+            if (card && card->_adaptiveCard) {
+                card->_refresh = [[ACORefresh alloc] init:card->_adaptiveCard->GetRefresh()];
+                card->_authentication = [[ACOAuthentication alloc] init:card->_adaptiveCard->GetAuthentication()];
+            }
+            result = [[ACOAdaptiveCardParseResult alloc] init:card errors:nil warnings:acrParseWarnings];
+        } catch (const AdaptiveCardParseException &e) {
+            // Converts AdaptiveCardParseException to NSError
+            ErrorStatusCode errorStatusCode = e.GetStatusCode();
+            NSInteger errorCode = (long)errorStatusCode;
+            NSBundle *adaptiveCardsBundle = [[ACOBundle getInstance] getBundle];
+            NSString *localizedFormat = NSLocalizedStringFromTableInBundle(@"AdaptiveCards.Parsing", nil, adaptiveCardsBundle, "Parsing Error Messages");
+            NSString *objectModelErrorCodeInString = [NSString stringWithCString:ErrorStatusCodeToString(errorStatusCode).c_str() encoding:NSUTF8StringEncoding];
+            NSDictionary<NSErrorUserInfoKey, id> *userInfo = @{NSLocalizedDescriptionKey : [NSString localizedStringWithFormat:localizedFormat, objectModelErrorCodeInString]};
+            NSError *parseError = [NSError errorWithDomain:ACRParseErrorDomain
+                                                      code:errorCode
+                                                  userInfo:userInfo];
+            NSArray<NSError *> *errors = @[ parseError ];
+
+            result = [[ACOAdaptiveCardParseResult alloc] init:nil errors:errors warnings:nil];
         }
     }
+
     return result;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACOAdaptiveCard.mm
@@ -82,20 +82,25 @@ using namespace AdaptiveCards;
             NSRange fullMatchRange = NSMakeRange(match.range.location + offset, match.range.length);
             NSRange regexStringRange = NSMakeRange([match rangeAtIndex:2].location + offset, [match rangeAtIndex:2].length);
 
-            // Extract the regex string
-            NSString *regexString = [mutablePayload substringWithRange:regexStringRange];
+            // Validate ranges to prevent out-of-bounds errors
+            if (NSLocationInRange(regexStringRange.location, NSMakeRange(0, mutablePayload.length)) &&
+                NSLocationInRange(NSMaxRange(regexStringRange), NSMakeRange(0, mutablePayload.length))) {
+                
+                // Extract the regex string
+                NSString *regexString = [mutablePayload substringWithRange:regexStringRange];
 
-            // Correct escaping: Replace each single backslash with two backslashes
-            NSString *correctedRegexString = [regexString stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"];
+                // Correct escaping: Replace each single backslash with two backslashes
+                NSString *correctedRegexString = [regexString stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"];
 
-            // Reconstruct the corrected full regex entry
-            NSString *correctedFullEntry = [NSString stringWithFormat:@"\"regex\": \"%@\"", correctedRegexString];
+                // Reconstruct the corrected full regex entry
+                NSString *correctedFullEntry = [NSString stringWithFormat:@"%@%@%@", [payload substringWithRange:[match rangeAtIndex:1]], correctedRegexString, [payload substringWithRange:[match rangeAtIndex:3]]];
 
-            // Replace the entire match with the corrected entry
-            [mutablePayload replaceCharactersInRange:fullMatchRange withString:correctedFullEntry];
+                // Replace the entire match with the corrected entry
+                [mutablePayload replaceCharactersInRange:fullMatchRange withString:correctedFullEntry];
 
-            // Update offset by the difference in length between corrected and original entries
-            offset += correctedFullEntry.length - fullMatchRange.length;
+                // Update offset by the difference in length between corrected and original entries
+                offset += correctedFullEntry.length - fullMatchRange.length;
+            }
         }
     }];
 


### PR DESCRIPTION
# Related Issue

N/A

# Description

This fixes faulty json processing of unescaped regex following the below url pattern for adaptive cards on iOS 


# Sample Broken JSON

"regex": "^([a-zA-Z0-9._%+-]+@outokumpu\.com)(,[a-zA-Z0-9._%+-]+@outokumpu\.com)*$",

# Sample Expected JSON

"regex": "^([a-zA-Z0-9._%+-]+@outokumpu\\.com)(,[a-zA-Z0-9._%+-]+@outokumpu\\.com)*$",




# How Verified

I validated the json payload in the `samples/v1.4/Tests/ActionExecute.With.Validation.json` substituting the broken json and attempting to render the card in the ACVisuzlier.

# Considerations

This technically fixes it but there are multiple approaches. We can anticipate an error and then retroactively attempt to apply this pattern as a fallback. We can also double down and add extra JSON parsing correctness using the Foundation JSON Serialization library and report on errors that way to attempt to create a more graceful solution.