### PR TITLE
[iOS] fix input action A11Y trait for links

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -237,6 +237,8 @@
                 if (![acoSelectAction isEnabled]) {
                     quickReplyView.accessibilityTraits |= UIAccessibilityTraitNotEnabled;
                 }
+            } else if (action->GetElementType() == ActionType::OpenUrl) {
+                button.accessibilityTraits = UIAccessibilityTraitLink;
             }
             [viewGroup addTarget:target];
         }


### PR DESCRIPTION
# Related Issue

Issue #178 

# Description

This PR fixes input action accessibility trait for links to the link trait.

# Sample Card

See card inputsWithValidation.json (V1.5 Scenario)

# How Verified

I verified using accessibility inspector.