### PR TITLE
Fix for no area specified in Area Grid

### DIFF
--- a/source/shared/cpp/ObjectModel/Column.cpp
+++ b/source/shared/cpp/ObjectModel/Column.cpp
@@ -198,7 +198,7 @@ std::shared_ptr<BaseCardElement> ColumnParser::Deserialize(ParseContext& context
                     stackLayout->SetLayoutContainerType(LayoutContainerType::Stack);
                     layouts.push_back(stackLayout);
                 }
-                else if (areaGridLayout->GetColumns().size() == 0)
+                else if (areaGridLayout->GetAreas().size() == 0)
                 {
                     // this needs to be flow layout
                     std::shared_ptr<FlowLayout> flowLayout = std::make_shared<FlowLayout>();

--- a/source/shared/cpp/ObjectModel/Container.cpp
+++ b/source/shared/cpp/ObjectModel/Container.cpp
@@ -111,7 +111,7 @@ std::shared_ptr<BaseCardElement> ContainerParser::Deserialize(ParseContext& cont
                     stackLayout->SetLayoutContainerType(LayoutContainerType::Stack);
                     layouts.push_back(stackLayout);
                 }
-                else if (areaGridLayout->GetColumns().size() == 0)
+                else if (areaGridLayout->GetAreas().size() == 0)
                 {
                     // this needs to be flow layout
                     std::shared_ptr<FlowLayout> flowLayout = std::make_shared<FlowLayout>();

--- a/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
+++ b/source/shared/cpp/ObjectModel/SharedAdaptiveCard.cpp
@@ -278,7 +278,7 @@ std::shared_ptr<ParseResult> AdaptiveCard::Deserialize(const Json::Value& json, 
                     stackLayout->SetLayoutContainerType(LayoutContainerType::Stack);
                     layouts.push_back(stackLayout);
                 }
-                else if (areaGridLayout->GetColumns().size() == 0)
+                else if (areaGridLayout->GetAreas().size() == 0)
                 {
                     // this needs to be flow layout
                     std::shared_ptr<FlowLayout> flowLayout = std::make_shared<FlowLayout>();

--- a/source/shared/cpp/ObjectModel/TableCell.cpp
+++ b/source/shared/cpp/ObjectModel/TableCell.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<TableCell> TableCell::DeserializeTableCell(ParseContext& context
                     stackLayout->SetLayoutContainerType(LayoutContainerType::Stack);
                     layouts.push_back(stackLayout);
                 }
-                else if (areaGridLayout->GetColumns().size() == 0)
+                else if (areaGridLayout->GetAreas().size() == 0)
                 {
                     // this needs to be flow layout
                     std::shared_ptr<FlowLayout> flowLayout = std::make_shared<FlowLayout>();


### PR DESCRIPTION
If there is no area specified in area grid, then it should behave as Flow layout. This case is not handled currently. 

To fix this we added check for no area in case of Area layout. We convert to flow layout in this case.  These changes are done in all layouts: column, container, TableCell and card
