### PR TITLE
[iOS]: Allow configuration of AC Fluent icon CDN paths for different environments

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomFeatureFlagResolver.m
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizer/ACRCustomFeatureFlagResolver.m
@@ -11,11 +11,13 @@
 
 @implementation ACRCustomFeatureFlagResolver
 
-- (NSArray *)arrayForFlag:(NSString *)flag { 
+- (NSArray *)arrayForFlag:(NSString *)flag 
+{
     return nil;
 }
 
-- (BOOL)boolForFlag:(NSString *)flag { 
+- (BOOL)boolForFlag:(NSString *)flag 
+{
     if([flag isEqualToString:@"isFlowLayoutEnabled"])
     {
         return YES;
@@ -29,15 +31,23 @@
     return NO;
 }
 
-- (NSDictionary *)dictForFlag:(NSString *)flag { 
+- (NSDictionary *)dictForFlag:(NSString *)flag 
+{
     return nil;
 }
 
-- (NSNumber *)numberForFlag:(NSString *)flag { 
+- (NSNumber *)numberForFlag:(NSString *)flag 
+{
     return nil;
 }
 
-- (NSString *)stringForFlag:(NSString *)flag { 
+- (NSString *)stringForFlag:(NSString *)flag 
+{
+    if ([flag isEqualToString:@"fluentIconCdnURL"])
+    {
+        return @"https://res-1.cdn.office.net/assets/fluentui-react-icons/2.0.226/";
+    }
+    
     return nil;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -12,6 +12,7 @@
 #import "ACRUIImageView.h"
 #import "ACRViewPrivate.h"
 #import "ACRSVGImageView.h"
+#import "UtiliOS.h"
 
 @implementation ACRButton
 
@@ -169,7 +170,7 @@
             // it is possible that host config has some size which is not available in CDN.
             unsigned int imageHeight = 24;
             BOOL isFilled = [[iconURL lowercaseString] containsString:@"filled"];
-            NSString *getSVGURL = [NSString stringWithCString:action->GetSVGInfoURL().c_str() encoding:[NSString defaultCStringEncoding]];
+            NSString *getSVGURL = cdnURLForIcon(@(action->GetSVGPath().c_str()));
             UIImageView *view = [[ACRSVGImageView alloc] init:getSVGURL rtl:rootView.context.rtl isFilled:isFilled size:CGSizeMake(imageHeight, imageHeight) tintColor:button.currentTitleColor];
             button.iconView = view;
             [button addSubview:view];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
@@ -132,7 +132,8 @@
                                       rootView:(ACRView *)rootView
                                     hostConfig:(ACOHostConfig *)acoConfig;
 {
-    NSString *svgPayloadURL = @(icon->GetSVGInfoURL().c_str());
+    
+    NSString *svgPayloadURL = cdnURLForIcon(@(icon->GetSVGPath().c_str()));
     UIColor *imageTintColor = [acoConfig getTextBlockColor:(ACRContainerStyle::ACRDefault) textColor:icon->getForgroundColor() subtleOption:false];
     
     CGSize size = CGSizeMake(getIconSize(icon->getIconSize()), getIconSize(icon->getIconSize()));

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIconRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIconRenderer.mm
@@ -45,7 +45,7 @@
     std::shared_ptr<BaseCardElement> elem = [acoElem element];
     std::shared_ptr<Icon> icon = std::dynamic_pointer_cast<Icon>(elem);
     
-    NSString *svgPayloadURL = @(icon->GetSVGInfoURL().c_str());
+    NSString *svgPayloadURL = cdnURLForIcon(@(icon->GetSVGPath().c_str()));
     CGSize size = CGSizeMake(getIconSize(icon->getIconSize()), getIconSize(icon->getIconSize()));
     
     UIColor *imageTintColor = [acoConfig getTextBlockColor:(ACRContainerStyle::ACRDefault) textColor:icon->getForgroundColor() subtleOption:false];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRSVGImageView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRSVGImageView.mm
@@ -9,6 +9,7 @@
 #import "ACRSVGImageView.h"
 #import "Icon.h"
 #import "ACRErrors.h"
+#import "UtiliOS.h"
 #ifdef SWIFT_PACKAGE
 /// Swift Package Imports
 #import "SVGKit.h"
@@ -115,7 +116,7 @@
 {
     // we will always show hardcoded square icon as fallback
     NSString *fallbackURLName = @"Square";
-    NSString *fallBackURLString = [[NSString alloc] initWithFormat:@"%s%@/%@.json",AdaptiveCards::baseIconCDNUrl, fallbackURLName, fallbackURLName];
+    NSString *fallBackURLString = [[NSString alloc] initWithFormat:@"%@%@/%@.json", baseFluentIconCDNURL, fallbackURLName, fallbackURLName];
     NSURL *svgURL = [[NSURL alloc] initWithString:fallBackURLString];
     [self makeIconCDNRequestWithURL:svgURL completion:^(NSDictionary * _Nullable dict, NSError * _Nullable error) {
         if (dict != nil)

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
@@ -40,6 +40,8 @@ using namespace AdaptiveCards;
 
 extern const CGFloat kACRScalerTolerance;
 
+extern NSString const *baseFluentIconCDNURL;
+
 // configures tag and initial visibility of the given view. Toggle visibility action
 // will access the view by the tag to change the visibility.
 void configVisibility(UIView *view, std::shared_ptr<BaseCardElement> const &visibilityInfo);
@@ -180,3 +182,7 @@ NSString* stringWithRemovedBackslashedSymbols(NSString *stringToRemoveSymbols, N
 BOOL isNullOrEmpty(NSString *string);
 
 NSString *stringForCString(const std::optional<std::string> cString);
+
+//CDN URL for icon path
+NSString *cdnURLForIcon(NSString *iconPath);
+

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -30,6 +30,7 @@ using namespace AdaptiveCards;
 
 // tolerance value for computing scaler for background cover size
 const CGFloat kACRScalerTolerance = 0.025f;
+NSString const *baseFluentIconCDNURL = @"https://res-1.cdn.office.net/assets/fluentui-react-icons/2.0.226/";
 
 void configVisibility(UIView *view, std::shared_ptr<BaseCardElement> const &visibilityInfo)
 {
@@ -1293,4 +1294,11 @@ NSString *stringForCString(const std::optional<std::string> cString)
     }
     
     return [NSString stringWithCString:cStr encoding:NSUTF8StringEncoding];
+}
+
+NSString *cdnURLForIcon(NSString *iconPath)
+{
+    NSObject<ACRIFeatureFlagResolver> *featureFlagResolver = [[ACRRegistration getInstance] getFeatureFlagResolver];
+    NSString const *CDNPath = [featureFlagResolver stringForFlag:@"fluentIconCdnURL"] ?: baseFluentIconCDNURL;
+    return [[NSString alloc] initWithFormat:@"%@%@",CDNPath, iconPath];
 }

--- a/source/shared/cpp/ObjectModel/BaseActionElement.cpp
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.cpp
@@ -38,7 +38,7 @@ const std::string& BaseActionElement::GetIconUrl() const
     return m_iconUrl;
 }
 
-std::string BaseActionElement::GetSVGInfoURL() const
+std::string BaseActionElement::GetSVGPath() const
 {
     std::regex regex{R"([,:]+)"}; // split on ':' and ','
     std::sregex_token_iterator it{m_iconUrl.begin(), m_iconUrl.end(), regex, -1};
@@ -51,7 +51,7 @@ std::string BaseActionElement::GetSVGInfoURL() const
             iconStyle = config[config.size() - 1];
         }
     }
-    std::string m_url = baseIconCDNUrl + iconName + "/" + iconName + ".json";
+    std::string m_url = iconName + "/" + iconName + ".json";
     return m_url;
 }
 

--- a/source/shared/cpp/ObjectModel/BaseActionElement.h
+++ b/source/shared/cpp/ObjectModel/BaseActionElement.h
@@ -30,7 +30,7 @@ public:
     virtual void SetTitle(const std::string& value);
 
     const std::string& GetIconUrl() const;
-    std::string GetSVGInfoURL() const;
+    std::string GetSVGPath() const;
 
     void SetIconUrl(std::string&& value);
     void SetIconUrl(const std::string& value);

--- a/source/shared/cpp/ObjectModel/Icon.cpp
+++ b/source/shared/cpp/ObjectModel/Icon.cpp
@@ -138,15 +138,14 @@ void Icon::PopulateKnownPropertiesSet()
 void Icon::GetResourceInformation(std::vector<RemoteResourceInformation>& resourceInfo)
 {
     RemoteResourceInformation imageResourceInfo;
-    imageResourceInfo.url = GetSVGInfoURL();
+    imageResourceInfo.url = GetSVGPath();
     imageResourceInfo.mimeType = "image";
     resourceInfo.push_back(imageResourceInfo);
 }
 
-std::string Icon::GetSVGInfoURL() const
+std::string Icon::GetSVGPath() const
 {
     // format: "<baseIconCDNUrl><Icon Name>/<IconName>.json"
-    // https://res-1.cdn.office.net/assets/fluentui-react-icons/2.0.226/Rss/Rss.json
-    std::string m_url = baseIconCDNUrl + GetName() + "/" + GetName() + ".json";
+    std::string m_url = GetName() + "/" + GetName() + ".json";
     return m_url;
 }

--- a/source/shared/cpp/ObjectModel/Icon.h
+++ b/source/shared/cpp/ObjectModel/Icon.h
@@ -7,11 +7,6 @@
 #include "BaseCardElement.h"
 #include "ElementParserRegistration.h"
 
-namespace AdaptiveCards {
-    // This is CDN base url for all fluent svg icons
-    constexpr const char* const baseIconCDNUrl = "https://res-1.cdn.office.net/assets/fluentui-react-icons/2.0.226/";
-}
-
 namespace AdaptiveCards
 {
 class Icon : public BaseCardElement
@@ -41,7 +36,7 @@ public:
     std::shared_ptr<BaseActionElement> GetSelectAction() const;
     void SetSelectAction(const std::shared_ptr<BaseActionElement> action);
 
-    std::string GetSVGInfoURL() const;
+    std::string GetSVGPath() const;
 
     void GetResourceInformation(std::vector<RemoteResourceInformation>& resourceInfo) override;
 

--- a/source/shared/cpp/ObjectModel/IconInfo.cpp
+++ b/source/shared/cpp/ObjectModel/IconInfo.cpp
@@ -113,10 +113,9 @@ void IconInfo::PopulateKnownPropertiesSet()
          AdaptiveCardSchemaKeyToString(AdaptiveCardSchemaKey::Style)});
 }
 
-std::string IconInfo::GetSVGInfoURL() const
+std::string IconInfo::GetSVGPath() const
 {
     // format: "<baseIconCDNUrl><Icon Name>/<IconName>.json"
-    // https://res-1.cdn.office.net/assets/fluentui-react-icons/2.0.226/Rss/Rss.json
-    std::string m_url = baseIconCDNUrl + GetName() + "/" + GetName() + ".json";
+    std::string m_url = GetName() + "/" + GetName() + ".json";
     return m_url;
 }

--- a/source/shared/cpp/ObjectModel/IconInfo.h
+++ b/source/shared/cpp/ObjectModel/IconInfo.h
@@ -21,7 +21,7 @@ namespace AdaptiveCards {
         ~IconInfo() = default;
         Json::Value SerializeToJsonValue() const;
         static std::shared_ptr<IconInfo> Deserialize(const Json::Value& json);
-        std::string GetSVGInfoURL() const;
+        std::string GetSVGPath() const;
 
         ForegroundColor getForgroundColor() const;
         void setForgroundColor(const ForegroundColor value);


### PR DESCRIPTION
# Description

Currently, Fluent icon assets for AC are served from this unique CDN path:
https://res-1.cdn.office.net/assets/fluentui-react-icons/2.0.226/

But the base path for this CDN should actually be different based on the environment. This PR uses FeatureFlagResolver to fetch root CDN URL from host application. 

if host doesn't provide value for flag "fluentIconCdnURL", then we will use existing default url. 