### PR TITLE
[iOS] Fix: Container vertical resizing may fail for large images

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContainerRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContainerRenderer.mm
@@ -116,15 +116,8 @@
     }
     
     NSString *areaName = stringForCString(elem->GetAreaGridName());
-    [viewGroup addArrangedSubview:container withAreaName:areaName];
     
     [self configureBorderForElement:acoElem container:container config:acoConfig];
-
-    configBleed(rootView, elem, container, acoConfig);
-
-    renderBackgroundImage(containerElem->GetBackgroundImage(), container, rootView);
-
-    container.frame = viewGroup.frame;
 
     [container setClipsToBounds:NO];
 
@@ -136,7 +129,13 @@
                                   minHeight:containerElem->GetMinHeight()
                                  heightType:GetACRHeight(containerElem->GetHeight())
                                        type:ACRContainer];
+    
+    [viewGroup addArrangedSubview:container withAreaName:areaName];
 
+    configBleed(rootView, elem, container, acoConfig);
+
+    renderBackgroundImage(containerElem->GetBackgroundImage(), container, rootView);
+    
     [rootView.context popBaseCardElementContext:acoElem];
 
     container.accessibilityElements = [container getArrangedSubviews];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContainerRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContainerRenderer.mm
@@ -49,6 +49,7 @@
     std::shared_ptr<Layout> final_layout = [[[ACRLayoutHelper alloc] init] layoutToApplyFrom:containerElem->GetLayouts() andHostConfig:acoConfig];
     ACRFlowLayout *flowContainer;
     ARCGridViewLayout *gridLayout;
+    BOOL useStackLayout = NO;
     if(final_layout->GetLayoutContainerType() == LayoutContainerType::Flow)
     {
         NSObject<ACRIFeatureFlagResolver> *featureFlagResolver = [[ACRRegistration getInstance] getFeatureFlagResolver];
@@ -91,6 +92,10 @@
                               andHostConfig:acoConfig];
         }
     }
+    else
+    {
+        useStackLayout = YES;
+    }
 
     ACRColumnView *container = [[ACRColumnView alloc] initWithStyle:(ACRContainerStyle)containerElem->GetStyle()
                                                         parentStyle:[viewGroup style]
@@ -102,11 +107,23 @@
     {
         [container addArrangedSubview:flowContainer];
     }
-    else if (gridLayout != nil) 
+    else if (gridLayout != nil)
     {
         [container addArrangedSubview:gridLayout];
-    } 
-    else
+    }
+    
+    NSString *areaName = stringForCString(elem->GetAreaGridName());
+    [viewGroup addArrangedSubview:container withAreaName:areaName];
+    
+    [self configureBorderForElement:acoElem container:container config:acoConfig];
+
+    configBleed(rootView, elem, container, acoConfig);
+
+    renderBackgroundImage(containerElem->GetBackgroundImage(), container, rootView);
+
+    container.frame = viewGroup.frame;
+    
+    if (useStackLayout)
     {
         [ACRRenderer render:container
                    rootView:rootView
@@ -114,10 +131,6 @@
               withCardElems:containerElem->GetItems()
               andHostConfig:acoConfig];
     }
-    
-    NSString *areaName = stringForCString(elem->GetAreaGridName());
-    
-    [self configureBorderForElement:acoElem container:container config:acoConfig];
 
     [container setClipsToBounds:NO];
 
@@ -129,13 +142,7 @@
                                   minHeight:containerElem->GetMinHeight()
                                  heightType:GetACRHeight(containerElem->GetHeight())
                                        type:ACRContainer];
-    
-    [viewGroup addArrangedSubview:container withAreaName:areaName];
 
-    configBleed(rootView, elem, container, acoConfig);
-
-    renderBackgroundImage(containerElem->GetBackgroundImage(), container, rootView);
-    
     [rootView.context popBaseCardElementContext:acoElem];
 
     container.accessibilityElements = [container getArrangedSubviews];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIView.h
@@ -21,7 +21,7 @@ const extern NSInteger eACRUIImageTag;
 @property BOOL isMediaType;
 @property (weak, readonly) UIView *contentView;
 
-- (instancetype)initWithImageProperties:(ACRImageProperties *)imageProperties imageView:(UIImageView *)imageView viewGroup:(ACRContentStackView *)viewGroup;
+- (instancetype)initWithImageProperties:(ACRImageProperties *)imageProperties imageView:(UIImageView *)imageView viewGroup:(id<ACRIContentHoldingView>)viewGroup;
 - (void)update:(ACRImageProperties *)imageProperties;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIView.mm
@@ -154,17 +154,7 @@ using namespace AdaptiveCards;
                     [self setImageViewHeightConstraint];
                 }
             }
-//            if (bUpdate) {
-//                if ([(ACRColumnView *)_viewGroup isKindOfClass:[ACRColumnView class]]) {
-//                    ACRColumnSetView *columnSetView = ((ACRColumnView *)_viewGroup).columnsetView;
-//                    if (columnSetView) {
-//                        [columnSetView updateIntrinsicContentSize];
-//                        [columnSetView invalidateIntrinsicContentSize];
-//                    }
-//                }
-//                [(ACRColumnView *)_viewGroup invalidateIntrinsicContentSize];
-//            }
-
+           
             if (bUpdate) 
             {
                 NSObject *container = (NSObject *)_viewGroup;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentHoldingUIView.mm
@@ -154,6 +154,16 @@ using namespace AdaptiveCards;
                     [self setImageViewHeightConstraint];
                 }
             }
+//            if (bUpdate) {
+//                if ([(ACRColumnView *)_viewGroup isKindOfClass:[ACRColumnView class]]) {
+//                    ACRColumnSetView *columnSetView = ((ACRColumnView *)_viewGroup).columnsetView;
+//                    if (columnSetView) {
+//                        [columnSetView updateIntrinsicContentSize];
+//                        [columnSetView invalidateIntrinsicContentSize];
+//                    }
+//                }
+//                [(ACRColumnView *)_viewGroup invalidateIntrinsicContentSize];
+//            }
 
             if (bUpdate) 
             {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRImageRenderer.mm
@@ -67,7 +67,7 @@
         view.image = img;
     }
 
-    ACRContentHoldingUIView *wrappingView = [[ACRContentHoldingUIView alloc] initWithImageProperties:imageProps imageView:view viewGroup:(ACRContentStackView *)viewGroup];
+    ACRContentHoldingUIView *wrappingView = [[ACRContentHoldingUIView alloc] initWithImageProperties:imageProps imageView:view viewGroup:viewGroup];
 
     if (!view || !wrappingView) {
         [viewGroup addSubview:wrappingView];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -249,8 +249,7 @@ using namespace AdaptiveCards;
 
     for (const auto &elem : elems) {
         ACRSeparator *separator = nil;
-        BOOL isGridView = ([view isKindOfClass:[ARCGridViewLayout class]]);
-        if (!isGridView && *firstelem != elem && renderedView && elem->MeetsTargetWidthRequirement(hostWidth)) {
+        if (*firstelem != elem && renderedView && elem->MeetsTargetWidthRequirement(hostWidth)) {
             separator = [ACRSeparator renderSeparation:elem
                                           forSuperview:view
                                         withHostConfig:[config getHostConfig]];


### PR DESCRIPTION
# Issue
In Teams client, container with large image were not getting resized properly. There can be gap below container. It happens only in stack layout and only in Teams. 

# Fix
Reverted stack layout changes in container. We will add the vertical container first then render children. 
Before we rendered all children of container then added to view group. 
Now we will add the container to view group then add children. 


