### PR TITLE
[iOS] - Fix for luminosity ratio on placeholder (issue 167)

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextView.mm
@@ -21,7 +21,7 @@
     if (self) {
         self.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
         if (@available(iOS 13.0, *)) {
-            _placeholderColor = [UIColor placeholderTextColor];
+            _placeholderColor = [UIColor colorWithRed:0.4313 green:0.4313 blue:0.4313 alpha:1.0];
         } else {
             // Fallback on earlier versions
             _placeholderColor = [UIColor lightGrayColor];


### PR DESCRIPTION
Fix for issue https://github.com/microsoft/Teams-AdaptiveCards-Mobile/issues/167 .

After fix:
<img width="565" alt="Screenshot 2024-09-23 at 11 01 06 p m" src="https://github.com/user-attachments/assets/a8dfac36-b52d-4408-a4f1-79d3d4a6bec4">
