### PR TITLE
[iOS]Add support for accessibility for stars in Rating Input

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.h
@@ -37,5 +37,6 @@
 + (void)commonSetFocus:(BOOL)shouldBecomeFirstResponder view:(UIView *)view;
 + (BOOL)commonTextUIValidate:(BOOL)isRequired hasText:(BOOL)hasText predicate:(NSPredicate *)predicate text:(NSString *)text error:(NSError *__autoreleasing *)error;
 - (NSObject<ACRIBaseInputHandler> *)getInputHandler;
+- (void)addAccessibleItems:(NSArray *)items;
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -166,6 +166,16 @@
     return self;
 }
 
+- (void)addAccessibleItems:(NSArray *)items
+{
+    if (items != nil)
+    {
+        NSMutableArray *accessibilityElements = [[NSMutableArray alloc] initWithArray:items];
+        [accessibilityElements insertObject:self.inputAccessibilityItem atIndex:0];
+        self.accessibilityElements = accessibilityElements;
+    }
+}
+
 - (void)setRtl:(ACRRtl)rtl
 {
     if (rtl == ACRRtlNone) {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingInputRenderer.mm
@@ -82,6 +82,8 @@
     ACRInputLabelView *inputLabelView = [[ACRInputLabelView alloc] initInputLabelView:rootView acoConfig:acoConfig adaptiveInputElement:ratingInput inputView:wrapperView accessibilityItem:ratingView viewGroup:viewGroup dataSource:ratingInputDataSource];
     
     [inputs addObject:inputLabelView];
+    
+    [inputLabelView addAccessibleItems:[ratingView accessibleChildren]];
 
     NSString *areaName = stringForCString(elem->GetAreaGridName());
     [viewGroup addArrangedSubview:inputLabelView withAreaName:areaName];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingView.h
@@ -36,6 +36,7 @@
 
 - (NSInteger)getValue;
 - (void)setValue:(NSInteger)value;
+- (NSArray *)accessibleChildren;
 
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingView.mm
@@ -18,6 +18,7 @@
     ACRRatingStyle _style;
     ACOHostConfig *_hostConfig;
     NSMutableArray<UIImageView *> *_starImageViews;
+    NSMutableArray<UIImageView *> *_accessibleChildren;
     UILabel *_ratingLabel;
     NSInteger _max;
     double _value;
@@ -44,6 +45,7 @@
         _count = 0;
         _style = ACRDefaultStyle;
         _hostConfig = hostConfig;
+        _accessibleChildren = [NSMutableArray array];
         [self setupViewForInput];
     }
     return self;
@@ -73,6 +75,11 @@
     return self;
 }
 
+- (NSArray *)accessibleChildren
+{
+    return [_accessibleChildren copy];
+}
+
 - (void)setupViewForInput
 {
     _starImageViews = [NSMutableArray array];
@@ -84,8 +91,11 @@
         [self addSubview:starImageView];
         [_starImageViews addObject:starImageView];
         starImageView.userInteractionEnabled = YES;
+        starImageView.isAccessibilityElement = YES;
+        starImageView.accessibilityLabel = [NSString stringWithFormat:@"Rate %d Star", (int)i+1];
         UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleStarTap:)];
         [starImageView addGestureRecognizer:tapGesture];
+        [_accessibleChildren addObject:starImageView];
     }
     
     [self setupConstraints];
@@ -116,6 +126,15 @@
     _ratingLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _ratingLabel.translatesAutoresizingMaskIntoConstraints = NO;
     _ratingLabel.attributedText = [self atrributedStringForLabel];
+    if (_count > 0)
+    {
+        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f,", (float)_value];
+    }
+    else
+    {
+        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f, Count %d", (float)_value, (int)_count];
+    }
+    
     [self addSubview:_ratingLabel];
     
     [self setupConstraints];


### PR DESCRIPTION
# Related Issue

Fixes #187

# Description
Starts inside rating input were not accessible before.  InputLableView wasn't allowing to have multiple inputs. 
We added support for it now. 

