### PR TITLE
[iOS] Copy of fix missing accessibility designation for ACRUILabel

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRUILabel.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRUILabel.mm
@@ -48,6 +48,7 @@
         }
     }
     _area = area;
+    [self updateAccessibility];
 }
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
@@ -88,6 +89,12 @@
             }
         }
     }
+}
+
+- (void)updateAccessibility
+{
+    self.isAccessibilityElement = YES;
+    self.accessibilityHint = self.text;
 }
 
 - (ACRBaseTarget *)retrieveTarget:(UIGestureRecognizer *)gestureRecognizer


### PR DESCRIPTION
This is a duplicate of PR https://github.com/microsoft/Teams-AdaptiveCards-Mobile/pull/248 , created to avoid pipeline issues.