### PR TITLE
[iOS] [AVP] - Fix for highlighted text not visible on Vision Pro.

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
@@ -164,6 +164,18 @@
                     UIColor *highlightColor = [acoConfig getHighlightColor:style
                                                            foregroundColor:textRun->GetTextColor().value_or(ForegroundColor::Default)
                                                               subtleOption:textRun->GetIsSubtle().value_or(false)];
+                    #if TARGET_OS_VISION
+                    // Reduce alpha component and add shadow to ensure is visible on Vision Pro
+                    highlightColor = [highlightColor colorWithAlphaComponent:0.3];
+                    
+                    NSShadow *shadow = [[NSShadow alloc] init];
+                    [shadow setShadowColor:[UIColor darkGrayColor]];
+                    [shadow setShadowOffset:CGSizeMake(0, 1.0f)];
+                    [textRunContent addAttribute:NSShadowAttributeName
+                                           value:shadow
+                                           range:NSMakeRange(0, textRunContent.length)];
+                    #endif
+                    
                     [textRunContent addAttribute:NSBackgroundColorAttributeName
                                            value:highlightColor
                                            range:NSMakeRange(0, textRunContent.length)];


### PR DESCRIPTION
Decreased alpha and added shadow for highlighted text to prevent non-visible text on Apple Vision Pro.

Before:
![avp-issue](https://github.com/user-attachments/assets/173179a8-d122-4ab7-9164-3383d75a2c1e)
After:
![Simulator Screenshot - Apple Vision Pro - 2024-10-04 at 11 49 35](https://github.com/user-attachments/assets/8d9fca20-1cc3-470b-879e-d2725221fcf8)
