### PR TITLE
[iOS] extra small spacing

### DIFF
--- a/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
+++ b/source/android/adaptivecards/src/main/cpp/objectmodel_wrap.cpp
@@ -31728,6 +31728,34 @@ SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectMod
 }
 
 
+SWIGEXPORT void JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_SpacingConfig_1extraSmallSpacing_1set(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2) {
+  AdaptiveCards::SpacingConfig *arg1 = (AdaptiveCards::SpacingConfig *) 0 ;
+  unsigned int arg2 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(AdaptiveCards::SpacingConfig **)&jarg1; 
+  arg2 = (unsigned int)jarg2; 
+  if (arg1) (arg1)->extraSmallSpacing = arg2;
+}
+
+
+SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_SpacingConfig_1extraSmallSpacing_1get(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+  jlong jresult = 0 ;
+  AdaptiveCards::SpacingConfig *arg1 = (AdaptiveCards::SpacingConfig *) 0 ;
+  unsigned int result;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(AdaptiveCards::SpacingConfig **)&jarg1; 
+  result = (unsigned int) ((arg1)->extraSmallSpacing);
+  jresult = (jlong)result; 
+  return jresult;
+}
+
+
 SWIGEXPORT jlong JNICALL Java_io_adaptivecards_objectmodel_AdaptiveCardObjectModelJNI_SpacingConfig_1Deserialize(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2, jobject jarg2_) {
   jlong jresult = 0 ;
   Json::Value *arg1 = 0 ;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardObjectModelJNI.java
@@ -1535,6 +1535,8 @@ public class AdaptiveCardObjectModelJNI {
   public final static native long SpacingConfig_extraLargeSpacing_get(long jarg1, SpacingConfig jarg1_);
   public final static native void SpacingConfig_paddingSpacing_set(long jarg1, SpacingConfig jarg1_, long jarg2);
   public final static native long SpacingConfig_paddingSpacing_get(long jarg1, SpacingConfig jarg1_);
+  public final static native void SpacingConfig_extraSmallSpacing_set(long jarg1, SpacingConfig jarg1_, long jarg2);
+  public final static native long SpacingConfig_extraSmallSpacing_get(long jarg1, SpacingConfig jarg1_);
   public final static native long SpacingConfig_Deserialize(long jarg1, JsonValue jarg1_, long jarg2, SpacingConfig jarg2_);
   public final static native long new_SpacingConfig();
   public final static native void delete_SpacingConfig(long jarg1);

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardSchemaKey.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/AdaptiveCardSchemaKey.java
@@ -254,7 +254,8 @@ public enum AdaptiveCardSchemaKey {
   Pages,
   PageAnimation,
   PageControl,
-  SelectedTintColor;
+  SelectedTintColor,
+  ExtraSmall;
 
   public final int swigValue() {
     return swigValue;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/Spacing.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/Spacing.java
@@ -11,6 +11,7 @@ package io.adaptivecards.objectmodel;
 public enum Spacing {
   Default(0),
   None,
+  ExtraSmall,
   Small,
   Medium,
   Large,

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/SpacingConfig.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/objectmodel/SpacingConfig.java
@@ -84,6 +84,14 @@ public class SpacingConfig {
     return AdaptiveCardObjectModelJNI.SpacingConfig_paddingSpacing_get(swigCPtr, this);
   }
 
+  public void setExtraSmallSpacing(long value) {
+    AdaptiveCardObjectModelJNI.SpacingConfig_extraSmallSpacing_set(swigCPtr, this, value);
+  }
+
+  public long getExtraSmallSpacing() {
+    return AdaptiveCardObjectModelJNI.SpacingConfig_extraSmallSpacing_get(swigCPtr, this);
+  }
+
   public static SpacingConfig Deserialize(JsonValue json, SpacingConfig defaultValue) {
     return new SpacingConfig(AdaptiveCardObjectModelJNI.SpacingConfig_Deserialize(JsonValue.getCPtr(json), json, SpacingConfig.getCPtr(defaultValue), defaultValue), true);
   }

--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/resources/sample.json
@@ -1,11 +1,12 @@
 {
 	"spacing": {
-		"small": 3,
-		"default": 8,
-		"medium": 20,
-		"large": 30,
-		"extraLarge": 40,
-		"padding": 10
+		"extraSmall":4,
+		"small": 8,
+		"default": 10,
+		"medium": 12,
+		"large": 16,
+		"extraLarge": 20,
+		"padding": 8
 	},
     "hostWidthBreakpoints": {
           "veryNarrow": 216,

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -927,6 +927,8 @@ unsigned int getSpacing(Spacing spacing, std::shared_ptr<HostConfig> const &conf
             return config->GetSpacing().paddingSpacing;
         case Spacing::Default:
             return config->GetSpacing().defaultSpacing;
+        case Spacing::ExtraSmall:
+            return config->GetSpacing().extraSmallSpacing;
         default:
             break;
     }

--- a/source/shared/cpp/ObjectModel/Enums.cpp
+++ b/source/shared/cpp/ObjectModel/Enums.cpp
@@ -251,6 +251,7 @@ namespace AdaptiveCards
             {AdaptiveCardSchemaKey::PageAnimation,"pageAnimation"},
             {AdaptiveCardSchemaKey::PageControl,"pageControl"},
             {AdaptiveCardSchemaKey::SelectedTintColor,"selectedTintColor"},
+            {AdaptiveCardSchemaKey::ExtraSmall,"extraSmall"},
             {AdaptiveCardSchemaKey::Wrap, "wrap"}});
 
     DEFINE_ADAPTIVECARD_ENUM(CardElementType, {
@@ -318,6 +319,7 @@ namespace AdaptiveCards
             {Spacing::Medium, "medium"},
             {Spacing::Large, "large"},
             {Spacing::ExtraLarge, "extraLarge"},
+            {Spacing::ExtraSmall, "extraSmall"},
             {Spacing::Padding, "padding"}});
 
     DEFINE_ADAPTIVECARD_ENUM(SeparatorThickness, {

--- a/source/shared/cpp/ObjectModel/Enums.h
+++ b/source/shared/cpp/ObjectModel/Enums.h
@@ -253,7 +253,8 @@ enum class AdaptiveCardSchemaKey
     Pages,
     PageAnimation,
     PageControl,
-    SelectedTintColor
+    SelectedTintColor,
+    ExtraSmall
 };
 
 DECLARE_ADAPTIVECARD_ENUM(AdaptiveCardSchemaKey);
@@ -483,6 +484,7 @@ enum class Spacing
 {
     Default = 0,
     None,
+    ExtraSmall,
     Small,
     Medium,
     Large,

--- a/source/shared/cpp/ObjectModel/HostConfig.cpp
+++ b/source/shared/cpp/ObjectModel/HostConfig.cpp
@@ -411,7 +411,9 @@ SpacingConfig SpacingConfig::Deserialize(const Json::Value& json, const SpacingC
     result.extraLargeSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::ExtraLarge, defaultValue.extraLargeSpacing);
 
     result.paddingSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::Padding, defaultValue.paddingSpacing);
-
+    
+    result.extraSmallSpacing = ParseUtil::GetUInt(json, AdaptiveCardSchemaKey::ExtraSmall, defaultValue.extraSmallSpacing);
+    
     return result;
 }
 

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -168,7 +168,7 @@ struct SpacingConfig
     unsigned int largeSpacing = 30;
     unsigned int extraLargeSpacing = 40;
     unsigned int paddingSpacing = 20;
-
+    unsigned int extraSmallSpacing = 4;
     static SpacingConfig Deserialize(const Json::Value& json, const SpacingConfig& defaultValue);
 };
 


### PR DESCRIPTION


# Description

This PR introduces "ExtraSmall" spacing for iOS.

Now spacing can contain following values.

"None", "ExtraSmall", "Small", "Default", "Medium", "Large", "ExtraLarge", "Padding"
