### PR TITLE
Added support for horizontal alignment in badge

### DIFF
--- a/samples/HostConfig/microsoft-teams-light.json
+++ b/samples/HostConfig/microsoft-teams-light.json
@@ -354,7 +354,7 @@
 				"textColor": "#ffffff"
 			},
 			"tint": {
-				"backgroundColor": "#e8b8fa",
+				"backgroundColor": "#e8ebfa",
 				"strokeColor": "#e1e1e1",
 				"textColor": "#5b5fc7"
 			}

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/BadgeRenderer.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/BadgeRenderer.kt
@@ -39,9 +39,7 @@ object BadgeRenderer: BaseCardElementRenderer() {
         badgeView.layoutParams = FlexboxLayout.LayoutParams(FlexboxLayout.LayoutParams.WRAP_CONTENT, FlexboxLayout.LayoutParams.WRAP_CONTENT)
         if (viewGroup is LinearLayout) {
             val linearLayoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
-            badge.GetHorizontalAlignment()?.let {
-                linearLayoutParams.gravity = it.getLinearLayoutGravity()
-            }
+            linearLayoutParams.gravity = badge.GetHorizontalAlignment().getLinearLayoutGravity()
             viewGroup.addView(badgeView, linearLayoutParams)
         } else {
             viewGroup.addView(badgeView)
@@ -53,11 +51,11 @@ object BadgeRenderer: BaseCardElementRenderer() {
     private fun HorizontalAlignment?.getLinearLayoutGravity() : Int =
         this?.let {
             when (this) {
-                HorizontalAlignment.Right -> Gravity.RIGHT
+                HorizontalAlignment.Right -> Gravity.END
                 HorizontalAlignment.Center -> Gravity.CENTER
-                else -> Gravity.LEFT
+                else -> Gravity.START
             }
         } ?: run {
-            Gravity.LEFT
+            Gravity.START
         }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/BadgeRenderer.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/BadgeRenderer.kt
@@ -50,9 +50,14 @@ object BadgeRenderer: BaseCardElementRenderer() {
         return badgeView
     }
 
-    private fun HorizontalAlignment.getLinearLayoutGravity() : Int = when(this) {
-        HorizontalAlignment.Left -> Gravity.LEFT
-        HorizontalAlignment.Right -> Gravity.RIGHT
-        else -> Gravity.CENTER
-    }
+    private fun HorizontalAlignment?.getLinearLayoutGravity() : Int =
+        this?.let {
+            when (this) {
+                HorizontalAlignment.Right -> Gravity.RIGHT
+                HorizontalAlignment.Center -> Gravity.CENTER
+                else -> Gravity.LEFT
+            }
+        } ?: run {
+            Gravity.LEFT
+        }
 }

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/BadgeRenderer.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/BadgeRenderer.kt
@@ -1,12 +1,15 @@
 package io.adaptivecards.renderer.readonly
 
 import android.content.Context
+import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import androidx.fragment.app.FragmentManager
 import com.google.android.flexbox.FlexboxLayout
 import io.adaptivecards.objectmodel.Badge
 import io.adaptivecards.objectmodel.BaseCardElement
+import io.adaptivecards.objectmodel.HorizontalAlignment
 import io.adaptivecards.objectmodel.HostConfig
 import io.adaptivecards.renderer.BaseCardElementRenderer
 import io.adaptivecards.renderer.RenderArgs
@@ -34,7 +37,22 @@ object BadgeRenderer: BaseCardElementRenderer() {
         val badgeView = BadgeView(context, badge, renderedCard, hostConfig)
         badgeView.tag = TagContent(badge)
         badgeView.layoutParams = FlexboxLayout.LayoutParams(FlexboxLayout.LayoutParams.WRAP_CONTENT, FlexboxLayout.LayoutParams.WRAP_CONTENT)
-        viewGroup.addView(badgeView)
+        if (viewGroup is LinearLayout) {
+            val linearLayoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+            badge.GetHorizontalAlignment()?.let {
+                linearLayoutParams.gravity = it.getLinearLayoutGravity()
+            }
+            viewGroup.addView(badgeView, linearLayoutParams)
+        } else {
+            viewGroup.addView(badgeView)
+        }
+
         return badgeView
+    }
+
+    private fun HorizontalAlignment.getLinearLayoutGravity() : Int = when(this) {
+        HorizontalAlignment.Left -> Gravity.LEFT
+        HorizontalAlignment.Right -> Gravity.RIGHT
+        else -> Gravity.CENTER
     }
 }

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -461,7 +461,7 @@ struct BadgeStylesDefinition
             "#ffffff"
             },
         {
-            "#e8b8fa",
+            "#e8ebfa",
             "#e1e1e1",
             "#5b5fc7"
         }


### PR DESCRIPTION
# Related Issue

HorizontalAlignment property is not getting applied for badge.
Accent tint colour needs to be changed based on figma.

# Description

If the parent container is LinearLayout, gravity is added based on horizontalAlignment property

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

# How Verified

Screenshot attached
![image](https://github.com/user-attachments/assets/4b0d27e0-69ea-4da0-a5b8-ac521906b536)

