### PR TITLE
fixed gestures

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCarouselView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCarouselView.mm
@@ -98,7 +98,6 @@
     
     [carouselStackView addArrangedSubview:carouselPagesContainerView];
     [carouselStackView addArrangedSubview:self.pageControl];
-    [carouselStackView addArrangedSubview:[[UIView alloc] initWithFrame:CGRectZero]];
     
     NSString *areaName = stringForCString(elem->GetAreaGridName());
     

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCarouselView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCarouselView.mm
@@ -97,7 +97,11 @@
     carouselStackView.clipsToBounds = YES;
     
     [carouselStackView addArrangedSubview:carouselPagesContainerView];
-    [carouselStackView addArrangedSubview:self.pageControl];
+    
+    if (self.carouselPageViewList.count > 1)
+    {
+        [carouselStackView addArrangedSubview:self.pageControl];
+    }
     
     NSString *areaName = stringForCString(elem->GetAreaGridName());
     

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRDirectionalPanGestureRecognizer.m
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRDirectionalPanGestureRecognizer.m
@@ -47,13 +47,6 @@ static NSTimeInterval const ACRkPanCancelSeconds = 0.2;
     
     [self stopTimeoutTimer];
     
-    // Ignore the edges of the screen to avoid being triggered by navigation gestures
-    if (self.beginPoint.x < ACRkEdgeIgnoreSpacing || self.beginPoint.x > self.view.bounds.size.width - ACRkEdgeIgnoreSpacing)
-    {
-        self.state = UIGestureRecognizerStateCancelled;
-        return;
-    }
-
     // Need to cancel this gesture so long-press gesture can trigger, cancel if haven't moved the touch after a time delay
     __weak typeof(self) weakSelf = self;
     self.timeoutTimer = [NSTimer scheduledTimerWithTimeInterval:ACRkPanCancelSeconds repeats:NO block:^(NSTimer * _Nonnull timer) {


### PR DESCRIPTION
# Related Issue

This PR fixes swipe left and right swipe issues on carousel. The swipe actions do not work if you swipe from leftmost or rightmost part of the card.

Also fixes for  redundant vertical space remaining when there is only carouselPage in Carousel
