### PR TITLE
[iOS][AC][Badge]  Fix for Tooltip doesn't work on long press

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBadgeView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBadgeView.mm
@@ -95,6 +95,7 @@
 {
     if (view && toolTipText && toolTipText.length) {
         UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(showToolTip:)];
+        longPress.minimumPressDuration = 0.32f;
         [view addGestureRecognizer:longPress];
     }
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBadgeView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBadgeView.mm
@@ -33,6 +33,7 @@
     UIView *_iconImageView;
     UILabel *_textLabel;
     ACRView *_rootView;
+    UILongPressGestureRecognizer *_longPressGesture;
 }
 
 
@@ -94,9 +95,10 @@
 - (void)addGestureRecognizer:(UIView *)view toolTipText:(NSString *)toolTipText
 {
     if (view && toolTipText && toolTipText.length) {
-        UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(showToolTip:)];
-        longPress.minimumPressDuration = 0.32f;
-        [view addGestureRecognizer:longPress];
+        _longPressGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self
+                                                                                                action:@selector(showToolTip:)];
+        _longPressGesture.delegate = self;
+        [view addGestureRecognizer:_longPressGesture];
     }
 }
 
@@ -107,6 +109,14 @@
         [MSFTooltip.shared showWith:_toolTip for:recognizer.view preferredArrowDirection:MSFTooltipArrowDirectionUp offset:CGPointZero screenMargins:MSFTooltip.defaultScreenMargins dismissOn:MSFTooltipDismissModeTapAnywhere onTap:nil];
     }
 #endif
+}
+
+-(BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    if(gestureRecognizer == _longPressGesture && [otherGestureRecognizer isKindOfClass:UILongPressGestureRecognizer.class])
+    {
+        return YES;
+    }
+    return NO;
 }
 
 -(CGFloat)getTextLabelFontSize

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRBadgeView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRBadgeView.h
@@ -9,7 +9,7 @@
 #import "ACRView.h"
 #import "ACOEnums.h"
 
-@interface ACRBadgeView : UIView
+@interface ACRBadgeView : UIView<UIGestureRecognizerDelegate>
 
 - (instancetype)initWithRootView:(ACRView *)rootView
                             text:(NSString*)text

--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |spec|
   end
 
   spec.subspec 'UIProviders' do | sspec |
-    sspec.dependency 'MicrosoftFluentUI/Tooltip_ios', '~> 0.3.6'
+    sspec.dependency 'MicrosoftFluentUI/Tooltip_ios', '~> 0.30.0'
     sspec.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ADAPTIVECARDS_USE_FLUENT_TOOLTIPS=1' }
   end
 
@@ -51,4 +51,3 @@ Pod::Spec.new do |spec|
   spec.exclude_files = 'source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/include/**/*'
 
 end
-


### PR DESCRIPTION
# Related Issue

This issue fixed the tooltip for badge element. A tooltip should appear upon long press on badge element.

# How Verified

Verified in teams . Below is the video attached

https://github.com/user-attachments/assets/723d378b-1348-4a69-9047-c8a85fd53043



