### PR TITLE
[iOS] add missing ACRRating headers to include directory

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/include/ACRRatingInputDataSource.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/include/ACRRatingInputDataSource.h
@@ -1,0 +1,1 @@
+../PrivateHeaders/ACRRatingInputDataSource.h

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/include/ACRRatingView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/include/ACRRatingView.h
@@ -1,0 +1,1 @@
+../ACRRatingView.h


### PR DESCRIPTION
https://github.com/microsoft/Teams-AdaptiveCards-Mobile/issues/126

Description
This fixes a regression for SPM support by including missing headers that were recently added for ratings components. Will need to update the CI to catch these regressions ahead of time.

How Verified
I included the AdaptiveCards-Mobile sdk in an iOS project using XCode 15.2 and set the SWIFT_PACKAGE=1 preprocessor setting in my XCode Build settings and built the project.

Going forward we should add a Github Action that builds the SPM as well as enforce the symlinking of C source headers to the include directory in line with SPM needs.