### PR TITLE
[AND]Changed toggle input wrap default value to true

### DIFF
--- a/source/shared/cpp/ObjectModel/ToggleInput.cpp
+++ b/source/shared/cpp/ObjectModel/ToggleInput.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<BaseCardElement> ToggleInputParser::Deserialize(ParseContext& co
 
     toggleInput->SetTitle(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Title, true));
     toggleInput->SetValue(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Value));
-    toggleInput->SetWrap(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, false, false));
+    toggleInput->SetWrap(ParseUtil::GetBool(json, AdaptiveCardSchemaKey::Wrap, true, false));
     toggleInput->SetValueOff(ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOff, std::string("false")));
     toggleInput->SetValueOn(ParseUtil::GetString(json, AdaptiveCardSchemaKey::ValueOn, std::string("true")));
 


### PR DESCRIPTION
# Related Issue

To align with desktop for toggle input wrap default behavior, when the property wrap is absent. It is default to true(See screenshot below). ADO ticket: https://domoreexp.visualstudio.com/MSTeams/_workitems/edit/3961889

![Screenshot 2025-01-29 at 4 41 16 PM](https://github.com/user-attachments/assets/87be8f01-33e7-44cf-9000-9724e77a321c)


# Description

Changed the default value for wrap in toggleInput to true

# Sample Card

`{
    "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
    "type": "AdaptiveCard",
    "version": "1.5",
    "body": [
        {
            "type": "TextBlock",
            "text": "Toggle Input"
        },
        {
            "type": "Input.Toggle",
            "id": "acceptTerms",
            "title": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit",
            "value": "true"
        }
    ],
    "actions": [
        {
            "type": "Action.Submit",
            "title": "OK"
        }
    ]
}`

# How Verified

Verified with sample payload above:

https://github.com/user-attachments/assets/0c3f8846-7943-4c18-a78e-de72aef4b1d0


