### PR TITLE
[Shared] Fix warning in shared-libs

### DIFF
--- a/source/shared/cpp/ObjectModel/Authentication.cpp
+++ b/source/shared/cpp/ObjectModel/Authentication.cpp
@@ -121,8 +121,8 @@ std::shared_ptr<Authentication> Authentication::Deserialize(ParseContext& contex
     authentication->SetConnectionName(ParseUtil::GetString(json, AdaptiveCardSchemaKey::ConnectionName));
     authentication->SetTokenExchangeResource(ParseUtil::DeserializeValue<TokenExchangeResource>(
         context, json, AdaptiveCardSchemaKey::TokenExchangeResource, TokenExchangeResource::Deserialize));
-    authentication->SetButtons(std::move(ParseUtil::GetElementCollectionOfSingleType<AuthCardButton>(
-        context, json, AdaptiveCardSchemaKey::Buttons, AuthCardButton::Deserialize)));
+    authentication->SetButtons(ParseUtil::GetElementCollectionOfSingleType<AuthCardButton>(
+        context, json, AdaptiveCardSchemaKey::Buttons, AuthCardButton::Deserialize));
 
     return authentication;
 }

--- a/source/shared/cpp/ObjectModel/Refresh.cpp
+++ b/source/shared/cpp/ObjectModel/Refresh.cpp
@@ -73,7 +73,7 @@ std::shared_ptr<Refresh> Refresh::Deserialize(ParseContext& context, const Json:
     std::shared_ptr<Refresh> refresh = std::make_shared<Refresh>();
 
     refresh->SetAction(ParseUtil::GetAction(context, json, AdaptiveCardSchemaKey::Action));
-    refresh->SetUserIds(std::move(ParseUtil::GetStringArray(json, AdaptiveCardSchemaKey::UserIds)));
+    refresh->SetUserIds(ParseUtil::GetStringArray(json, AdaptiveCardSchemaKey::UserIds));
 
     return refresh;
 }

--- a/source/shared/cpp/ObjectModel/json/json.h
+++ b/source/shared/cpp/ObjectModel/json/json.h
@@ -969,14 +969,15 @@ public:
     /// \brief Remove and return the named member.
     ///
     /// Do nothing if it did not exist.
-    /// \return the removed Value, or null.
     /// \pre type() is objectValue or nullValue
     /// \post type() is unchanged
     /// \deprecated
+    JSONCPP_DEPRECATED("Use removeMember(const char*, Value*) instead.")
     void removeMember(const char* key);
     /// Same as removeMember(const char*)
     /// \param key may contain embedded nulls.
     /// \deprecated
+    JSONCPP_DEPRECATED("Use removeMember(const char*, Value*) instead.")
     void removeMember(const JSONCPP_STRING& key);
     /// Same as removeMember(const char* begin, const char* end, Value* removed),
     /// but 'key' is null-terminated.


### PR DESCRIPTION
# Related Issue

Per Office Repo policies, no warning is allowed.

# Description

<img width="382" alt="image" src="https://github.com/user-attachments/assets/4b371975-129e-454b-beb9-6748eadc2b30" />

# How Verified

All the existing test run passed. And the warning is gone.
