### PR TITLE
[iOS] Fix: Add missing methods for views of ACRIBaseInputHandler

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetFilteredStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetFilteredStyleView.mm
@@ -153,6 +153,11 @@ using namespace AdaptiveCards;
     dictionary[self.id] = [_validator getValue:self.text];
 }
 
+- (void)resetInput
+{
+
+}
+
 #pragma mark - ACRChoiceSetTypeaheadSearchDelegate Methods
 
 - (void)updateSelectedChoiceInTextField:(NSString *)text

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetFilteredStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetFilteredStyleView.mm
@@ -32,6 +32,7 @@ using namespace AdaptiveCards;
     UIButton *_navigationButton;
     NSString *_typeaheadViewTitle;
     ACRTypeaheadStateAllParameters *_searchStateParams;
+    NSMutableArray<CompletionHandler> *_completionHandlers;
 }
 
 - (instancetype)initWithInputChoiceSet:(ACOBaseCardElement *)acoElem
@@ -51,6 +52,7 @@ using namespace AdaptiveCards;
         _typeaheadViewTitle = typeaheadViewTitle;
         _filteredDataSource = [[ACOFilteredDataSource alloc] init];
         _validator = [[ACOChoiceSetFilteredStyleValidator alloc] init:acoElem dataSource:_filteredDataSource];
+        _completionHandlers = [[NSMutableArray alloc] init];
 
         // configure UITextField
         self.delegate = self;
@@ -153,9 +155,20 @@ using namespace AdaptiveCards;
     dictionary[self.id] = [_validator getValue:self.text];
 }
 
+- (void)addObserverWithCompletion:(CompletionHandler)completion
+{
+    [_completionHandlers addObject:completion];
+}
+
+- (void)notifyObservers {
+    for(CompletionHandler completion in _completionHandlers) {
+        completion();
+    }
+}
+
 - (void)resetInput
 {
-
+    self.text = _validator.userInitialChoice;
 }
 
 #pragma mark - ACRChoiceSetTypeaheadSearchDelegate Methods
@@ -163,6 +176,7 @@ using namespace AdaptiveCards;
 - (void)updateSelectedChoiceInTextField:(NSString *)text
 {
     self.text = text;
+    [self notifyObservers];
 }
 
 - (NSString *)getSelectedText

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputLabelView.mm
@@ -362,6 +362,7 @@
 - (void)resetInput
 {
     [[self getInputHandler] resetInput];
+    [self validate:nil];
 }
 
 @synthesize hasValidationProperties;


### PR DESCRIPTION
# Related Issue

⚠️compiler warning: Class 'ACRInputLabelView' and 'ACRChoiceSetFilteredStyleView' do not conform to protocol 'ACRIBaseInputHandler'

# Description

Fix by adding the missing protocol methods

# How Verified

|before|after|
|-|-|
|<img width="697" alt="image" src="https://github.com/user-attachments/assets/54fd24ed-3c19-4ed3-9a51-6de090cc7324" /> | <img width="705" alt="image" src="https://github.com/user-attachments/assets/8bd55b9c-27e5-4a69-8d54-1c46bee70417" />|
