### PR TITLE
[iOS] mark base actions in protocol as MainActor for swift concurrency check

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIBaseActionElementRenderer.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIBaseActionElementRenderer.h
@@ -17,7 +17,7 @@
                     inputs:(NSMutableArray *)inputs
                  superview:(UIView *)superview
          baseActionElement:(ACOBaseActionElement *)acoElem
-                hostConfig:(ACOHostConfig *)acoConfig;
+                hostConfig:(ACOHostConfig *)acoConfig NS_SWIFT_UI_ACTOR;
 @end
 
 @protocol ACRIBaseActionSetRenderer
@@ -26,5 +26,5 @@
                    inputs:(NSMutableArray *)inputs
                 superview:(UIView<ACRIContentHoldingView> *)superview
                      card:(ACOAdaptiveCard *)card
-               hostConfig:(ACOHostConfig *)config;
+               hostConfig:(ACOHostConfig *)config NS_SWIFT_UI_ACTOR;
 @end


### PR DESCRIPTION
# Related Issue

Swift6 projects overriding custom action functions will cause compiler errors
<img width="981" alt="image" src="https://github.com/user-attachments/assets/0d6520c4-ddeb-49b3-bcad-5daf1b263dc3" />


# Description

Add swift concurrency attributes to base action protocol methods

# Sample Card

N/A

# How Verified

1. In a swift6 or concurrency checking with `complete` projects
2. import the framework, subclass to ACRBaseActionElementRenderer and implement protocol functions
3. when attribute added, compiler errors are gone
