### PR TITLE
Reverting regression in button

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.h
@@ -21,6 +21,9 @@
 @property UIColor *defaultDestructiveForegroundColor;
 @property ACRIconPlacement iconPlacement;
 @property ACRActionType actionType;
+@property __weak UIImageView *iconView;
+@property NSLayoutConstraint *heightConstraint;
+@property NSLayoutConstraint *titleWidthConstraint;
 
 + (UIButton *)rootView:(ACRView *)rootView
      baseActionElement:(ACOBaseActionElement *)acoAction

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -1,4 +1,3 @@
-
 //
 //  ACRButton
 //  ACRButton.mm
@@ -21,19 +20,74 @@
 {
     self = [super init];
     if (self) {
-        [self setup:expandable];
+        if (expandable) {
+            [self setupExpandableConfig];
+        } else {
+            [self setupDefaultConfig];
+        }
     }
     return self;
 }
 
-- (void)setup:(BOOL)expandable
+- (void)setupExpandableConfig
 {
+    self.backgroundColor = UIColor.systemBlueColor;
+    self.tintColor = UIColor.systemBackgroundColor;
+    
+    // Configure autoresizing mask
+    self.autoresizingMask = UIViewAutoresizingFlexibleWidth |
+    UIViewAutoresizingFlexibleHeight;
+    
+    // Set content insets (10 on all sides)
+    self.contentEdgeInsets = UIEdgeInsetsMake(10, 10, 10, 10);
+    
     // Set the title font (system font with a point size of 15)
     self.titleLabel.font = [UIFont systemFontOfSize:15];
+    
+    // Set images for various button states using SF Symbols (iOS 13+)
+    if (@available(iOS 13.0, *)) {
+        UIImage *chevronUp = [UIImage systemImageNamed:@"chevron.up"];
+        UIImage *chevronDown = [UIImage systemImageNamed:@"chevron.down"];
+        
+        [self setImage:chevronUp forState:UIControlStateNormal];
+        [self setImage:chevronUp forState:UIControlStateDisabled];
+        [self setImage:chevronDown forState:UIControlStateSelected];
+        [self setImage:chevronUp forState:UIControlStateHighlighted];
+    }
+    
+    // Set title color for normal state to white
+    [self setTitleColor:[UIColor colorWithWhite:1 alpha:1] forState:UIControlStateNormal];
+    
+    // Set corner radius
+    self.layer.cornerRadius = 10;
+    
+    // Custom runtime attributes translated as properties
+    self.positiveForegroundColor = [UIColor colorWithWhite:0.6666666667 alpha:1.0];
+    self.positiveBackgroundColor = [UIColor colorWithWhite:0.3333333333 alpha:1.0];
+    self.destructiveForegroundColor = [UIColor colorWithWhite:1 alpha:1];
+    self.destructiveBackgroundColor = [UIColor colorWithWhite:0.3333333333 alpha:1.0];
+    self.positiveUseDefault = YES;
+    self.destructiveUseDefault = NO;
+}
 
-    // Set the auto resizing mask
-    self.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-
+- (void)setupDefaultConfig
+{
+    self.backgroundColor = UIColor.systemBlueColor;
+    self.tintColor = UIColor.systemBlueColor;
+    
+    // Configure autoresizing mask
+    self.autoresizingMask = UIViewAutoresizingFlexibleWidth |
+    UIViewAutoresizingFlexibleHeight;
+    
+    // Content insets of 10 on all sides.
+    self.contentEdgeInsets = UIEdgeInsetsMake(10, 10, 10, 10);
+    
+    // Set title color for normal state to white.
+    [self setTitleColor:[UIColor colorWithWhite:1 alpha:1] forState:UIControlStateNormal];
+    
+    // Set corner radius.
+    self.layer.cornerRadius = 10;
+    
     // Custom runtime attributes translated as properties on ACRButton:
     self.positiveForegroundColor = [UIColor colorWithWhite:0.6666666667 alpha:1.0];
     self.positiveBackgroundColor = [UIColor colorWithWhite:0.3333333333 alpha:1.0];
@@ -41,44 +95,6 @@
     self.destructiveBackgroundColor = [UIColor colorWithWhite:0.3333333333 alpha:1.0];
     self.positiveUseDefault = YES;
     self.destructiveUseDefault = NO;
-
-    // Set this to avoid unexpected external modification to background color break the style.
-    self.layer.cornerRadius = 10;
-
-    // Create a filled button configuration
-    UIButtonConfiguration *buttonConfig = [UIButtonConfiguration filledButtonConfiguration];
-
-    // Set the default background and title colors
-    buttonConfig.baseBackgroundColor = UIColor.systemBlueColor;
-    buttonConfig.baseForegroundColor = UIColor.systemBackgroundColor; // title color
-
-    // Set the default content insets (10 on all sides)
-    buttonConfig.contentInsets = NSDirectionalEdgeInsetsMake(10, 10, 10, 10);
-
-    // Set the default corner radius on the background configuration
-    buttonConfig.background.cornerRadius = 10;
-
-    if (expandable) {
-        // Prepare images for different states
-        UIImage *chevronUp = [UIImage systemImageNamed:@"chevron.up"];
-        UIImage *chevronDown = [UIImage systemImageNamed:@"chevron.down"];
-
-        // Set a default image (for the normal state)
-        buttonConfig.image = chevronUp;
-
-        self.configurationUpdateHandler = ^(__kindof UIButton *_Nonnull button) {
-            UIButtonConfiguration *updatedConfig = button.configuration;
-            if (button.isSelected) {
-                updatedConfig.image = chevronDown;
-            } else {
-                updatedConfig.image = chevronUp;
-            }
-            // Re-assign the updated configuration back to the button
-            button.configuration = updatedConfig;
-        };
-    }
-
-    self.configuration = buttonConfig;
 }
 
 - (void)setImageView:(UIImage *)image
@@ -88,54 +104,99 @@
 }
 
 - (void)setImageView:(UIImage *)image
-            withConfig:(ACOHostConfig *)config
-    widthToHeightRatio:(float)widthToHeightRatio
+          withConfig:(ACOHostConfig *)config
+  widthToHeightRatio:(float)widthToHeightRatio
 {
     float imageHeight = 0.0f;
-    float ratio = 1.0f;
-    CGSize contentSize = self.titleLabel.intrinsicContentSize;
-
+    CGSize contentSize = [self.titleLabel intrinsicContentSize];
+    
     // apply explicit image size when the below condition is met
     if (_iconPlacement == ACRAboveTitle) {
         imageHeight = [config getHostConfig]->GetActions().iconSize;
     } else { // format the image so it fits in the button
         imageHeight = contentSize.height;
     }
-
+    
     if (image && image.size.height > 0) {
-        ratio = image.size.width / image.size.height;
+        widthToHeightRatio = image.size.width / image.size.height;
     }
-
-    CGSize imageSize = CGSizeMake(imageHeight * ratio, imageHeight);
-
-    UIButtonConfiguration *buttonConfiguration = self.configuration;
-
-    buttonConfiguration.image = image;
-
-    // Resize the image to desired size
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:imageSize];
-    buttonConfiguration.image = [[renderer imageWithActions:^(__unused UIGraphicsImageRendererContext *_Nonnull rendererContext) {
-        [image drawInRect:CGRectMake(0, 0, imageSize.width, imageSize.height)];
-    }] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
-
-    // Set the image on the button
-    buttonConfiguration.imagePadding = [config getHostConfig]->GetSpacing().defaultSpacing;
-
+    
+    CGSize imageSize = CGSizeMake(imageHeight * widthToHeightRatio, imageHeight);
+    _iconView.translatesAutoresizingMaskIntoConstraints = NO;
+    
+    // scale the image using UIImageView
+    [NSLayoutConstraint constraintWithItem:_iconView
+                                 attribute:NSLayoutAttributeWidth
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:nil
+                                 attribute:NSLayoutAttributeNotAnAttribute
+                                multiplier:1.0
+                                  constant:imageSize.width]
+        .active = YES;
+    
+    [NSLayoutConstraint constraintWithItem:_iconView
+                                 attribute:NSLayoutAttributeHeight
+                                 relatedBy:NSLayoutRelationEqual
+                                    toItem:nil
+                                 attribute:NSLayoutAttributeNotAnAttribute
+                                multiplier:1.0
+                                  constant:imageSize.height]
+        .active = YES;
+    
+    int iconPadding = [config getHostConfig]->GetSpacing().defaultSpacing;
+    
     if (_iconPlacement == ACRAboveTitle) {
-        // Set the image placement to the top
-        buttonConfiguration.imagePlacement = NSDirectionalRectEdgeTop;
-    } else {
-        // Otherwise, set the image placement to the leading edge
-        buttonConfiguration.imagePlacement = NSDirectionalRectEdgeLeading;
+        // fix image view to top and center x of the button
+        [NSLayoutConstraint constraintWithItem:_iconView
+                                     attribute:NSLayoutAttributeTop
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:self
+                                     attribute:NSLayoutAttributeTop
+                                    multiplier:1.0
+                                      constant:self.contentEdgeInsets.top]
+            .active = YES;
+        [NSLayoutConstraint constraintWithItem:_iconView
+                                     attribute:NSLayoutAttributeCenterX
+                                     relatedBy:NSLayoutRelationEqual
+                                        toItem:self
+                                     attribute:NSLayoutAttributeCenterX
+                                    multiplier:1.0
+                                      constant:0]
+            .active = YES;
+        // image can't be postion at the top of the title, so adjust title inset edges
+        [self setTitleEdgeInsets:UIEdgeInsetsMake(0, iconPadding, -imageHeight - iconPadding, 0)];
+        [self setImageEdgeInsets:UIEdgeInsetsMake(0, 0, -imageHeight - iconPadding, 0)];
+        CGFloat insetConstant = (imageSize.height + iconPadding) / 2;
+        [self setContentEdgeInsets:UIEdgeInsetsMake(self.contentEdgeInsets.top + insetConstant, 0, self.contentEdgeInsets.bottom + insetConstant, 0)];
+    } else if (_iconPlacement != ACRNoTitle) {
+        int npadding = 0;
+        if (self.doesItHaveAnImageView) {
+            iconPadding += (self.imageView.frame.size.width + iconPadding);
+            npadding = [config getHostConfig]->GetSpacing().defaultSpacing;
+        }
+        CGFloat widthOffset = (imageSize.width + iconPadding);
+        
+        [self setContentEdgeInsets:UIEdgeInsetsMake(self.contentEdgeInsets.top, self.contentEdgeInsets.left + widthOffset / 2, self.contentEdgeInsets.bottom, self.contentEdgeInsets.right + widthOffset / 2)];
+        [self setTitleEdgeInsets:UIEdgeInsetsMake(0, npadding, 0, -(widthOffset + npadding))];
+        [_iconView.trailingAnchor constraintEqualToAnchor:self.titleLabel.leadingAnchor constant:-iconPadding].active = YES;
+        
+        [NSLayoutConstraint constraintWithItem:_iconView attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0].active = YES;
+        CGFloat offset = -(self.contentEdgeInsets.left + self.contentEdgeInsets.right);
+        
+        self.titleWidthConstraint = [self.titleLabel.widthAnchor constraintLessThanOrEqualToAnchor:self.widthAnchor constant:offset];
+        self.titleWidthConstraint.active = YES;
+        
+        [self.titleLabel.centerXAnchor constraintEqualToAnchor:self.centerXAnchor constant:(widthOffset / 2)].active = YES;
+        
+        self.heightConstraint = [self.heightAnchor constraintGreaterThanOrEqualToAnchor:self.titleLabel.heightAnchor constant:self.contentEdgeInsets.top + self.contentEdgeInsets.bottom];
+        self.heightConstraint.active = YES;
     }
-
-    self.configuration = buttonConfiguration;
 }
 
 + (UIButton *)rootView:(ACRView *)rootView
      baseActionElement:(ACOBaseActionElement *)acoAction
                  title:(NSString *)title
-         andHostConfig:(ACOHostConfig *)config
+         andHostConfig:(ACOHostConfig *)config;
 {
     ACRButton *button = [[ACRButton alloc] initWithExpandable:[acoAction type] == ACRShowCard];
     [button setTitle:title forState:UIControlStateNormal];
@@ -148,121 +209,98 @@
     } else {
         button.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     }
-
+    
     button.isAccessibilityElement = YES;
     button.accessibilityLabel = title;
     button.enabled = [acoAction isEnabled];
-
+    
     button.sentiment = acoAction.sentiment;
     button.actionType = acoAction.type;
-
+    
     button.defaultPositiveBackgroundColor = [config getTextBlockColor:(ACRContainerStyle::ACRDefault) textColor:(ForegroundColor::Accent)subtleOption:false];
     button.defaultDestructiveForegroundColor = [config getTextBlockColor:(ACRContainerStyle::ACRDefault) textColor:(ForegroundColor::Attention)subtleOption:false];
     [button applySentimentStyling];
-
+    
     std::shared_ptr<AdaptiveCards::BaseActionElement> action = [acoAction element];
-    BOOL isSplitButton = action->GetIsSplitAction();
     NSDictionary *imageViewMap = [rootView getImageMap];
-    ACTheme theme = ACTheme(rootView.theme);
-    NSString *iconURL = [NSString stringWithCString:action->GetIconUrl(theme).c_str() encoding:[NSString defaultCStringEncoding]];
+    NSString *iconURL = [NSString stringWithCString:action->GetIconUrl(ACTheme(rootView.theme)).c_str() encoding:[NSString defaultCStringEncoding]];
     NSString *key = iconURL;
-    UIImage *image = imageViewMap[key];
-    button.iconPlacement = [ACRButton getIconPlacementAtCurrentContext:rootView url:key];
-
-    if (image) {
-        [button setImageView:image withConfig:config];
+    UIImage *img = imageViewMap[key];
+    button.iconPlacement = [ACRButton getIconPlacmentAtCurrentContext:rootView url:key];
+    
+    if (img) {
+        UIImageView *iconView = [[ACRUIImageView alloc] init];
+        iconView.image = img;
+        [button addSubview:iconView];
+        button.iconView = iconView;
+        [button setImageView:img withConfig:config];
     } else if (key.length) {
         NSNumber *number = [NSNumber numberWithUnsignedLongLong:(unsigned long long)action.get()];
-        NSString *k = [number stringValue];
-        UIImageView *view = [rootView getImageView:k];
+        NSString *key = [number stringValue];
+        UIImageView *view = [rootView getImageView:key];
         if ([iconURL hasPrefix:@"icon:"]) {
             // Rendering svg fluent icon here on button
-
+            
             // intentionally kept this 24 so that it always loads
             // irrespective of size given in host config.
             // it is possible that host config has some size which is not available in CDN.
             unsigned int imageHeight = 24;
             BOOL isFilled = [[iconURL lowercaseString] containsString:@"filled"];
             NSString *getSVGURL = cdnURLForIcon(@(action->GetSVGPath([iconURL UTF8String]).c_str()));
-            [ACRSVGImageView requestIcon:getSVGURL
-                                  filled:isFilled
-                                    size:CGSizeMake(imageHeight, imageHeight)
-                                     rtl:rootView.context.rtl
-                              completion:^(UIImage *icon) {
-                                  [button setImageView:icon withConfig:config widthToHeightRatio:1.0f];
-                              }];
+            UIImageView *view = [[ACRSVGImageView alloc] init:getSVGURL rtl:rootView.context.rtl isFilled:isFilled size:CGSizeMake(imageHeight, imageHeight) tintColor:button.currentTitleColor];
+            button.iconView = view;
+            [button addSubview:view];
+            [button setImageView:view.image withConfig:config widthToHeightRatio:1.0f];
         } else if (view) {
             if (view.image) {
+                button.iconView = view;
+                [button addSubview:view];
+                [rootView removeObserverOnImageView:@"image" onObject:view keyToImageView:key];
                 [button setImageView:view.image withConfig:config];
-                [rootView removeObserverOnImageView:@"image" onObject:view keyToImageView:k];
+            } else {
+                button.iconView = view;
+                [button addSubview:view];
+                [rootView setImageView:key view:button];
             }
         }
-    }
-    
-    if (isSplitButton)
-    {
-        NSString *chevronDownIcon = @"ChevronDown";
-        NSString *url = [[NSString alloc] initWithFormat:@"%@%@/%@.json", baseFluentIconCDNURL, chevronDownIcon, chevronDownIcon];
-        UIImageView *view = [[ACRSVGImageView alloc] init:url rtl:rootView.context.rtl isFilled:true size:CGSizeMake(16, 16) tintColor:button.currentTitleColor];
-        [button addSubview:view];
-        NSString *title = [button titleForState:UIControlStateNormal];
-        UIFont *font = button.titleLabel.font;
-        CGSize titleSize = [title sizeWithAttributes:@{NSFontAttributeName: font}];
-        CGFloat totalWidth = titleSize.width + 16;
-        view.translatesAutoresizingMaskIntoConstraints = NO;
-        view.contentMode = UIViewContentModeScaleAspectFit;
-        [view.widthAnchor constraintEqualToConstant:16].active = YES;
-        [view.heightAnchor constraintEqualToConstant:16].active = YES;
-        [NSLayoutConstraint activateConstraints:@[
-            [view.trailingAnchor constraintEqualToAnchor:button.trailingAnchor constant:-8],
-            [view.centerYAnchor constraintEqualToAnchor:button.centerYAnchor],
-            [view.widthAnchor constraintEqualToConstant:16],
-            [view.heightAnchor constraintEqualToConstant:16],
-            [button.widthAnchor constraintEqualToConstant:totalWidth]
-        ]];
+    } else {
+        button.heightConstraint = [button.heightAnchor constraintGreaterThanOrEqualToAnchor:button.titleLabel.heightAnchor constant:button.contentEdgeInsets.top + button.contentEdgeInsets.bottom];
+        button.heightConstraint.active = YES;
     }
     
     if (button.isEnabled == NO) {
-        UIButtonConfiguration *buttonConfiguration = button.configuration;
-        buttonConfiguration.baseBackgroundColor = [buttonConfiguration.baseBackgroundColor colorWithAlphaComponent:0.5];
-        button.configuration = buttonConfiguration;
+        [button setBackgroundColor:[button.backgroundColor colorWithAlphaComponent:0.5]];
     }
-
+    
     return button;
-}
-
-- (void)setBackgroundColor:(UIColor *)backgroundColor
-{
-    [super setBackgroundColor:backgroundColor];
-    UIButtonConfiguration *buttonConfiguration = self.configuration;
-    buttonConfiguration.baseBackgroundColor = backgroundColor;
-    self.configuration = buttonConfiguration;
 }
 
 - (void)applySentimentStyling
 {
-    UIButtonConfiguration *buttonConfiguration = self.configuration;
     if ([@"positive" caseInsensitiveCompare:_sentiment] == NSOrderedSame) {
+        BOOL usePositiveDefault = _positiveUseDefault;
+        
         // By default, positive sentiment must have background accentColor and white text/foreground color
-        if (_positiveUseDefault) {
-            buttonConfiguration.baseBackgroundColor = _defaultPositiveBackgroundColor;
-            buttonConfiguration.baseForegroundColor = UIColor.whiteColor;
+        if (usePositiveDefault) {
+            [self setBackgroundColor:_defaultPositiveBackgroundColor];
+            [self setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
         } else {
-            // Otherwise use the defined values
-            buttonConfiguration.baseBackgroundColor = _positiveBackgroundColor;
-            buttonConfiguration.baseForegroundColor = _positiveForegroundColor;
+            // Otherwise use the values defined by the user in the ACRButton.xib
+            [self setBackgroundColor:_positiveBackgroundColor];
+            [self setTitleColor:_positiveForegroundColor forState:UIControlStateNormal];
         }
     } else if ([@"destructive" caseInsensitiveCompare:_sentiment] == NSOrderedSame) {
+        BOOL useDestructiveDefault = _destructiveUseDefault;
+        
         // By default, destructive sentiment must have a attention text/foreground color
-        if (_destructiveUseDefault) {
-            buttonConfiguration.baseForegroundColor = _defaultDestructiveForegroundColor;
+        if (useDestructiveDefault) {
+            [self setTitleColor:_defaultDestructiveForegroundColor forState:UIControlStateNormal];
         } else {
-            // Otherwise use the defined values
-            buttonConfiguration.baseBackgroundColor = _destructiveBackgroundColor;
-            buttonConfiguration.baseForegroundColor = _destructiveForegroundColor;
+            // Otherwise use the values defined by the user in the ACRButton.xib
+            [self setBackgroundColor:_destructiveBackgroundColor];
+            [self setTitleColor:_destructiveForegroundColor forState:UIControlStateNormal];
         }
     }
-    self.configuration = buttonConfiguration;
 }
 
 - (BOOL)doesItHaveAnImageView
@@ -270,16 +308,16 @@
     return (self.actionType == ACRShowCard && self.imageView && self.imageView.frame.size.width);
 }
 
-+ (ACRIconPlacement)getIconPlacementAtCurrentContext:(ACRView *)rootView url:(NSString *)key
++ (ACRIconPlacement)getIconPlacmentAtCurrentContext:(ACRView *)rootView url:(NSString *)key
 {
     if (!key or key.length == 0) {
         return ACRNoTitle;
     }
-
+    
     if ([rootView.context.hostConfig getIconPlacement] == ACRAboveTitle and rootView.context.allHasActionIcons) {
         return ACRAboveTitle;
     }
-
+    
     return ACRLeftOfTitle;
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -197,13 +197,19 @@
         if (img) {
             UIImageView *iconView = [[ACRUIImageView alloc] init];
             iconView.image = img;
+            [button addSubview:iconView];
+            button.iconView = iconView;
             [button setImageView:img withConfig:acoConfig];
         } else if (key.length) {
             NSNumber *number = [NSNumber numberWithUnsignedLongLong:(unsigned long long)action.get()];
             NSString *k = [number stringValue];
             UIImageView *view = [rootView getImageView:k];
+            button.iconView = view;
+            [button addSubview:view];
             if (view && view.image) {
                 [button setImageView:view.image withConfig:acoConfig];
+            } else {
+                [rootView setImageView:k view:button];
             }
             [NSLayoutConstraint constraintWithItem:button
                                          attribute:NSLayoutAttributeWidth


### PR DESCRIPTION
Regression on button is reverted:
- Issue : Icon not appearing on button
- Root cause: This https://github.com/microsoft/Teams-AdaptiveCards-Mobile/pull/304 has removed `iconView` on button and used button configuration to show icons to fix the `deprecated warning` while using `contentEdgeInsets`.
- Changes in this PR is reverting the above PR changes only specific to ACRButton.

Tested the changes with button icons, working fine and matching with before https://github.com/microsoft/Teams-AdaptiveCards-Mobile/pull/303 :
![Simulator Screenshot - iPhone 16 Pro - 2025-04-17 at 13 46 50](https://github.com/user-attachments/assets/941de138-39dd-496d-a143-2d512b9102fd)
![Simulator Screenshot - iPhone 16 Pro - 2025-04-17 at 13 47 01](https://github.com/user-attachments/assets/a9dc066b-f59c-472d-887a-48b99c36aa96)
![Simulator Screenshot - iPhone 16 Pro - 2025-04-17 at 13 47 05](https://github.com/user-attachments/assets/2eb55a25-a6bb-4a79-af7c-67ba41cc80ad)

