### PR TITLE
Button text size fixed

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -105,15 +105,7 @@
 
 - (void)setImageView:(UIImage *)image
           withConfig:(ACOHostConfig *)config
-  aspectRatio:(float)aspectRatio
-{
-    [self setImageView:image withConfig:config aspectRatio:aspectRatio imageSize:CGSizeZero];
-}
-
-- (void)setImageView:(UIImage *)image
-          withConfig:(ACOHostConfig *)config
-  aspectRatio:(float)aspectRatio
-           imageSize:(CGSize)imageSize
+         aspectRatio:(float)aspectRatio
 {
     CGFloat imageHeight = 0.0f;
     CGSize contentSize = [self.titleLabel intrinsicContentSize];
@@ -129,7 +121,7 @@
         aspectRatio = image.size.width / image.size.height;
     }
     
-    CGSize calculatedImageSize = CGSizeEqualToSize(imageSize, CGSizeZero) ? CGSizeMake(imageHeight * aspectRatio, imageHeight) : imageSize;
+    CGSize calculatedImageSize = CGSizeMake(imageHeight * aspectRatio, imageHeight);
     _iconView.translatesAutoresizingMaskIntoConstraints = NO;
     
     // scale the image using UIImageView
@@ -255,6 +247,11 @@
     button.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
     button.titleLabel.adjustsFontForContentSizeCategory = YES;
     [button.titleLabel setFont:[UIFont systemFontOfSize:15.0]];
+    if (button.titleLabel.font) {
+        button.titleLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:button.titleLabel.font];
+    } else {
+        button.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+    }
     button.isAccessibilityElement = YES;
     button.accessibilityLabel = title;
     button.enabled = [acoAction isEnabled];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -254,12 +254,7 @@
     button.titleLabel.numberOfLines = 0;
     button.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
     button.titleLabel.adjustsFontForContentSizeCategory = YES;
-    if (button.titleLabel.font) {
-        button.titleLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:button.titleLabel.font];
-    } else {
-        button.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    }
-    
+    [button.titleLabel setFont:[UIFont systemFontOfSize:15.0]];
     button.isAccessibilityElement = YES;
     button.accessibilityLabel = title;
     button.enabled = [acoAction isEnabled];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -247,11 +247,7 @@
     button.titleLabel.lineBreakMode = NSLineBreakByWordWrapping;
     button.titleLabel.adjustsFontForContentSizeCategory = YES;
     [button.titleLabel setFont:[UIFont systemFontOfSize:15.0]];
-    if (button.titleLabel.font) {
-        button.titleLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:button.titleLabel.font];
-    } else {
-        button.titleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
-    }
+    button.titleLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:button.titleLabel.font];
     button.isAccessibilityElement = YES;
     button.accessibilityLabel = title;
     button.enabled = [acoAction isEnabled];


### PR DESCRIPTION
Button size was fixed in 2.9.16 version and when icon size is not specified icon inside button is scaled based on button text size.
Setting button text size to 15 in programmatic code to match the previous version expectation.


| 2.9.16 | Latest Main | Changes in this PR | 
|-------|-------------|--------------------|
|<img src="https://github.com/user-attachments/assets/e9f0921a-a42f-4f90-899f-5be2ac4c3375" width="240"/>| <img src="https://github.com/user-attachments/assets/183eddaa-836e-4485-bc43-d5de1950c732" width="240"/>| <img src="https://github.com/user-attachments/assets/297a9d47-b413-4a8f-ac1d-25f3a3617c7a" width="240"/>|