### PR TITLE
Fixed show card flow

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRShowCardTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRShowCardTarget.mm
@@ -39,9 +39,7 @@
         _rootView = rootView;
         _adcView = nil;
         _button = button;
-        std::shared_ptr<ShowCardAction> showCardAction = std::make_shared<ShowCardAction>();
-        showCardAction->SetCard(showCardActionElement->GetCard());
-        _actionElement = [[ACOBaseActionElement alloc] initWithBaseActionElement:std::dynamic_pointer_cast<BaseActionElement>(showCardAction)];
+        _actionElement = [[ACOBaseActionElement alloc] initWithBaseActionElement:std::dynamic_pointer_cast<BaseActionElement>(showCardActionElement)];
     }
     return self;
 }


### PR DESCRIPTION
Issue: Showcard flow was setting empty showcard action object and setting `card` property using `SetCard` method while rendering, this is causing all the details of show card action not available at the time of onClick event.

Fix: Setting actionElement as the original show card action element