### PR TITLE
[Android] Image fitMode implemented

### DIFF
--- a/samples/v1.5/Elements/Action.Popover.json
+++ b/samples/v1.5/Elements/Action.Popover.json
@@ -296,10 +296,30 @@
 			"type": "ActionSet",
 			"actions": [
 				{
-					"type": "Action.Submit",
-					"title": "Submit",
-					"iconUrl": "icon:Send,Filled",
+					"type": "Action.ShowCard",
+					"title": "ShowCard",
+					"iconUrl": "icon:Open,Filled",
+					"card": {
+						"type": "AdaptiveCard",
+						"body": [
+							{
+								"type": "TextBlock",
+								"text": "This is a show card"
+							},
+							{
+								"type": "Input.Text",
+								"id": "defaultInputIdShow2",
+								"placeholder": "enter comment",
+								"maxLength": 500
+							}
+						]
+					},
 					"menuActions": [
+						{
+							"type": "Action.Submit",
+							"title": "Submit",
+							"iconUrl": "icon:Send,Filled"
+						},
 						{
 							"type": "Action.OpenUrl",
 							"title": "OpenUrl",

--- a/samples/v1.5/Elements/Action.Popover.json
+++ b/samples/v1.5/Elements/Action.Popover.json
@@ -241,16 +241,93 @@
 					}
 				}
 			]
+		},
+		{
+			"type": "ActionSet",
+			"actions": [
+				{
+					"type": "Action.ShowCard",
+					"title": "ShowCard",
+					"iconUrl": "icon:Open,Filled",
+					"tooltip": "Tooltip for ShowCard",
+					"card": {
+						"type": "AdaptiveCard",
+						"body": [
+							{
+								"type": "TextBlock",
+								"text": "This is a show card"
+							},
+							{
+								"type": "Input.Text",
+								"id": "defaultInputIdShow",
+								"placeholder": "enter comment",
+								"maxLength": 500
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"type": "ActionSet",
+			"actions": [
+				{
+					"type": "Action.ToggleVisibility",
+					"title": "ToggleVisibility",
+					"iconUrl": "icon:ToggleLeft,Filled",
+					"tooltip": "Tooltip for ToggleVisibility",
+					"style": "positive",
+					"targetElements": [
+						"outsidePopover1",
+						"outsidePopover2"
+					]
+				},
+				{
+					"type": "Action.OpenUrl",
+					"title": "OpenUrl",
+					"iconUrl": "icon:Open,Filled",
+					"tooltip": "Tooltip for OpenUrl",
+					"style": "positive",
+					"url": "https://www.microsoft.com"
+				}
+			]
+		},
+		{
+			"type": "ActionSet",
+			"actions": [
+				{
+					"type": "Action.Submit",
+					"title": "Submit",
+					"iconUrl": "icon:Send,Filled",
+					"menuActions": [
+						{
+							"type": "Action.OpenUrl",
+							"title": "OpenUrl",
+							"iconUrl": "icon:Open,Filled",
+							"tooltip": "Tooltip for OpenUrl",
+							"style": "positive",
+							"url": "https://www.microsoft.com"
+						},
+						{
+							"type": "Action.ToggleVisibility",
+							"title": "ToggleVisibility",
+							"iconUrl": "icon:ToggleLeft,Filled",
+							"tooltip": "Tooltip for ToggleVisibility",
+							"style": "positive",
+							"targetElements": [
+								"outsidePopover1",
+								"outsidePopover2"
+							]
+						}
+					]
+				}
+			]
 		}
 	],
 	"actions": [
 		{
 			"type": "Action.Submit",
 			"title": "Submit"
-		},
-		{
-			"type": "Action.Execute",
-			"title": "Execute"
 		}
 	]
 }

--- a/samples/v1.5/Elements/Image.FitMode.Contain.json
+++ b/samples/v1.5/Elements/Image.FitMode.Contain.json
@@ -4,6 +4,18 @@
 	"body": [
 		{
 			"type": "Container",
+			"showBorder": true,
+			"roundedCorners": true,
+			"items": [
+				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Contain Mode Card"
+				}
+			]
+		},
+		{
+			"type": "Container",
 			"layouts": [
 				{}
 			],
@@ -11,7 +23,7 @@
 				{
 					"type": "TextBlock",
 					"size": "Large",
-					"text": "Potrait Image (Without fitMode)"
+					"text": "Potrait Image (Original Image)"
 				},
 				{
 					"type": "Image",
@@ -77,7 +89,7 @@
 				{
 					"type": "TextBlock",
 					"size": "Large",
-					"text": "Landscape Image (Without fitMode)"
+					"text": "Landscape Image (Original Image)"
 				},
 				{
 					"type": "Image",

--- a/samples/v1.5/Elements/Image.FitMode.Contain.json
+++ b/samples/v1.5/Elements/Image.FitMode.Contain.json
@@ -5,69 +5,23 @@
 		{
 			"type": "Container",
 			"layouts": [
-				{
-
-				}
+				{}
 			],
 			"items": [
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1A Contain Left Top"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Potrait Image (Without fitMode)"
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1A Contain Left Top"
-						}
-					]
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"size": "Medium"
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "left",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1B Contain Left Center"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Potrait Image (fitMode as Contain)"
 				},
 				{
 					"type": "Container",
@@ -77,266 +31,63 @@
 						{
 							"type": "Image",
 							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "contain",
-							"horizontalContentAlignment": "left",
-							"verticalContentAlignment": "center"
+							"horizontalContentAlignment": "left"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "1B Contain Left Center"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "left",
-							"verticalContentAlignment": "bottom"
+							"size": "Medium",
+							"text": "Horizontal Left"
 						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1C Contain Left Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
 						{
 							"type": "Image",
 							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "left",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1C Contain Left Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "contain",
 							"horizontalContentAlignment": "center"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "2A Contain Center Top"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
+							"size": "Medium",
+							"text": "Horizontal Center"
+						},
 						{
 							"type": "Image",
 							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2A Contain Center Top"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "center",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2B Contain Center Center"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "center",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2B Contain Center Center"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "center",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2C Contain Center Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "center",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2C Contain Center Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "contain",
 							"horizontalContentAlignment": "right"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "3A Contain Right Top"
+							"size": "Medium",
+							"text": "Horizontal Right"
 						}
 					]
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "right"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "3A Contain Right Top"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "   "
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "right",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "3B Contain Right Center"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Landscape Image (Without fitMode)"
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "right",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "3B Contain Right Center"
-						}
-					]
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"size": "Medium"
+				},
+				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Landscape Image (fitMode as Contain)"
 				},
 				{
 					"type": "Container",
@@ -346,37 +97,41 @@
 						{
 							"type": "Image",
 							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "contain",
-							"horizontalContentAlignment": "right",
-							"verticalContentAlignment": "bottom"
+							"verticalContentAlignment": "top"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "3C Contain Right Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
+							"size": "Medium",
+							"text": "Vertical Top"
+						},
 						{
 							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
+							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "contain",
-							"horizontalContentAlignment": "right",
+							"verticalContentAlignment": "center"
+						},
+						{
+							"type": "TextBlock",
+							"size": "Medium",
+							"text": "Vertical Center"
+						},
+						{
+							"type": "Image",
+							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+							"height": "250px",
+							"width": "250px",
+							"fitMode": "contain",
 							"verticalContentAlignment": "bottom"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "3C Contain Right Bottom"
+							"size": "Medium",
+							"text": "Vertical Bottom"
 						}
 					]
 				}

--- a/samples/v1.5/Elements/Image.FitMode.Contain.json
+++ b/samples/v1.5/Elements/Image.FitMode.Contain.json
@@ -23,7 +23,9 @@
 		{
 			"type": "Image",
 			"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-			"size": "Medium"
+			"height": "auto",
+			"width": "200px",
+			"fitMode": "contain"
 		},
 		{
 			"type": "TextBlock",
@@ -87,7 +89,9 @@
 		{
 			"type": "Image",
 			"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-			"size": "Medium"
+			"height": "200px",
+			"width": "auto",
+			"fitMode": "contain"
 		},
 		{
 			"type": "TextBlock",

--- a/samples/v1.5/Elements/Image.FitMode.Contain.json
+++ b/samples/v1.5/Elements/Image.FitMode.Contain.json
@@ -14,140 +14,134 @@
 				}
 			]
 		},
+
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "Potrait Image (Original Image)"
+		},
+		{
+			"type": "Image",
+			"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+			"size": "Medium"
+		},
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "Potrait Image (fitMode as Contain)"
+		},
 		{
 			"type": "Container",
-			"layouts": [
-				{}
-			],
+			"showBorder": true,
+			"roundedCorners": true,
 			"items": [
 				{
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "contain",
+					"horizontalContentAlignment": "left"
+				},
+				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "Potrait Image (Original Image)"
+					"size": "Medium",
+					"text": "Horizontal Left"
 				},
 				{
 					"type": "Image",
 					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-					"size": "Medium"
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "contain",
+					"horizontalContentAlignment": "center"
 				},
 				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "Potrait Image (fitMode as Contain)"
+					"size": "Medium",
+					"text": "Horizontal Center"
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "left"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Horizontal Left"
-						},
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Horizontal Center"
-						},
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "contain",
-							"horizontalContentAlignment": "right"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Horizontal Right"
-						}
-					]
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "contain",
+					"horizontalContentAlignment": "right"
 				},
 				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "   "
+					"size": "Medium",
+					"text": "Horizontal Right"
+				}
+			]
+		},
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "   "
+		},
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "Landscape Image (Original Image)"
+		},
+		{
+			"type": "Image",
+			"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+			"size": "Medium"
+		},
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "Landscape Image (fitMode as Contain)"
+		},
+		{
+			"type": "Container",
+			"showBorder": true,
+			"roundedCorners": true,
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "contain",
+					"verticalContentAlignment": "top"
 				},
 				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "Landscape Image (Original Image)"
+					"size": "Medium",
+					"text": "Vertical Top"
 				},
 				{
 					"type": "Image",
 					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-					"size": "Medium"
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "contain",
+					"verticalContentAlignment": "center"
 				},
 				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "Landscape Image (fitMode as Contain)"
+					"size": "Medium",
+					"text": "Vertical Center"
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "contain",
-							"verticalContentAlignment": "top"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Vertical Top"
-						},
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "contain",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Vertical Center"
-						},
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "contain",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Vertical Bottom"
-						}
-					]
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "contain",
+					"verticalContentAlignment": "bottom"
+				},
+				{
+					"type": "TextBlock",
+					"size": "Medium",
+					"text": "Vertical Bottom"
 				}
 			]
 		}
+
 	]
 }

--- a/samples/v1.5/Elements/Image.FitMode.Contain.json
+++ b/samples/v1.5/Elements/Image.FitMode.Contain.json
@@ -32,8 +32,6 @@
 		},
 		{
 			"type": "Container",
-			"showBorder": true,
-			"roundedCorners": true,
 			"items": [
 				{
 					"type": "Image",
@@ -98,8 +96,6 @@
 		},
 		{
 			"type": "Container",
-			"showBorder": true,
-			"roundedCorners": true,
 			"items": [
 				{
 					"type": "Image",

--- a/samples/v1.5/Elements/Image.FitMode.Cover.json
+++ b/samples/v1.5/Elements/Image.FitMode.Cover.json
@@ -23,7 +23,9 @@
 		{
 			"type": "Image",
 			"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-			"size": "Medium"
+			"height": "auto",
+			"width": "stretch",
+			"fitMode": "cover"
 		},
 		{
 			"type": "TextBlock",
@@ -87,7 +89,9 @@
 		{
 			"type": "Image",
 			"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-			"size": "Medium"
+			"height": "200px",
+			"width": "stretch",
+			"fitMode": "cover"
 		},
 		{
 			"type": "TextBlock",

--- a/samples/v1.5/Elements/Image.FitMode.Cover.json
+++ b/samples/v1.5/Elements/Image.FitMode.Cover.json
@@ -5,12 +5,25 @@
 		{
 			"type": "Container",
 			"layouts": [
-				{
-
-				}
+				{}
 			],
 			"items": [
 				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Potrait Image (Without fitMode)"
+				},
+				{
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"size": "Medium"
+				},
+				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Potrait Image (fitMode as Cover)"
+				},
+				{
 					"type": "Container",
 					"showBorder": true,
 					"roundedCorners": true,
@@ -18,77 +31,63 @@
 						{
 							"type": "Image",
 							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1A Cover Left Top"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1A Cover Left Top"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "cover",
-							"horizontalContentAlignment": "left",
+							"verticalContentAlignment": "top"
+						},
+						{
+							"type": "TextBlock",
+							"size": "Medium",
+							"text": "Vertical Top"
+						},
+						{
+							"type": "Image",
+							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+							"height": "250px",
+							"width": "250px",
+							"fitMode": "cover",
 							"verticalContentAlignment": "center"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "1B Cover Left Center"
+							"size": "Medium",
+							"text": "Vertical Center"
+						},
+						{
+							"type": "Image",
+							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+							"height": "250px",
+							"width": "250px",
+							"fitMode": "cover",
+							"verticalContentAlignment": "bottom"
+						},
+						{
+							"type": "TextBlock",
+							"size": "Medium",
+							"text": "Vertical Bottom"
 						}
 					]
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "left",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1B Cover Left Center"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "   "
+				},
+				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Landscape Image (Without fitMode)"
+				},
+				{
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"size": "Medium"
+				},
+				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Landscape Image (fitMode as Cover)"
 				},
 				{
 					"type": "Container",
@@ -98,285 +97,41 @@
 						{
 							"type": "Image",
 							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "cover",
-							"horizontalContentAlignment": "left",
-							"verticalContentAlignment": "bottom"
+							"horizontalContentAlignment": "left"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "1C Cover Left Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "left",
-							"verticalContentAlignment": "bottom"
+							"size": "Medium",
+							"text": "Horizontal Left"
 						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "1C Cover Left Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
 						{
 							"type": "Image",
 							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "cover",
 							"horizontalContentAlignment": "center"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "2A Cover Center Top"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "center"
+							"size": "Medium",
+							"text": "Horizontal Center"
 						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2A Cover Center Top"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
 						{
 							"type": "Image",
 							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "center",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2B Cover Center Center"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "center",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2B Cover Center Center"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "center",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2C Cover Center Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "center",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "2C Cover Center Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
+							"height": "250px",
+							"width": "250px",
 							"fitMode": "cover",
 							"horizontalContentAlignment": "right"
 						},
 						{
 							"type": "TextBlock",
-							"size": "Large",
-							"text": "3A Cover Right Top"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "right"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "3A Cover Right Top"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "right",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "3B Cover Right Center"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "right",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "3B Cover Right Center"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "right",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "3C Cover Right Bottom"
-						}
-					]
-				},
-				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "400px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "right",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "3C Cover Right Bottom"
+							"size": "Medium",
+							"text": "Horizontal Right"
 						}
 					]
 				}

--- a/samples/v1.5/Elements/Image.FitMode.Cover.json
+++ b/samples/v1.5/Elements/Image.FitMode.Cover.json
@@ -14,138 +14,131 @@
 				}
 			]
 		},
+
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "Potrait Image (Original Image)"
+		},
+		{
+			"type": "Image",
+			"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+			"size": "Medium"
+		},
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "Potrait Image (fitMode as Cover)"
+		},
 		{
 			"type": "Container",
-			"layouts": [
-				{}
-			],
+			"showBorder": true,
+			"roundedCorners": true,
 			"items": [
 				{
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "cover",
+					"verticalContentAlignment": "top"
+				},
+				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "Potrait Image (Original Image)"
+					"size": "Medium",
+					"text": "Vertical Top"
 				},
 				{
 					"type": "Image",
 					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-					"size": "Medium"
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "cover",
+					"verticalContentAlignment": "center"
 				},
 				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "Potrait Image (fitMode as Cover)"
+					"size": "Medium",
+					"text": "Vertical Center"
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "cover",
-							"verticalContentAlignment": "top"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Vertical Top"
-						},
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "cover",
-							"verticalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Vertical Center"
-						},
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "cover",
-							"verticalContentAlignment": "bottom"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Vertical Bottom"
-						}
-					]
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "cover",
+					"verticalContentAlignment": "bottom"
 				},
 				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "   "
+					"size": "Medium",
+					"text": "Vertical Bottom"
+				}
+			]
+		},
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "   "
+		},
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "Landscape Image (Original Image)"
+		},
+		{
+			"type": "Image",
+			"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+			"size": "Medium"
+		},
+		{
+			"type": "TextBlock",
+			"size": "Large",
+			"text": "Landscape Image (fitMode as Cover)"
+		},
+		{
+			"type": "Container",
+			"showBorder": true,
+			"roundedCorners": true,
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "cover",
+					"horizontalContentAlignment": "left"
 				},
 				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "Landscape Image (Original Image)"
+					"size": "Medium",
+					"text": "Horizontal Left"
 				},
 				{
 					"type": "Image",
 					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-					"size": "Medium"
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "cover",
+					"horizontalContentAlignment": "center"
 				},
 				{
 					"type": "TextBlock",
-					"size": "Large",
-					"text": "Landscape Image (fitMode as Cover)"
+					"size": "Medium",
+					"text": "Horizontal Center"
 				},
 				{
-					"type": "Container",
-					"showBorder": true,
-					"roundedCorners": true,
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "left"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Horizontal Left"
-						},
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "center"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Horizontal Center"
-						},
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "250px",
-							"width": "250px",
-							"fitMode": "cover",
-							"horizontalContentAlignment": "right"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Medium",
-							"text": "Horizontal Right"
-						}
-					]
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "250px",
+					"width": "250px",
+					"fitMode": "cover",
+					"horizontalContentAlignment": "right"
+				},
+				{
+					"type": "TextBlock",
+					"size": "Medium",
+					"text": "Horizontal Right"
 				}
 			]
 		}

--- a/samples/v1.5/Elements/Image.FitMode.Cover.json
+++ b/samples/v1.5/Elements/Image.FitMode.Cover.json
@@ -4,6 +4,18 @@
 	"body": [
 		{
 			"type": "Container",
+			"showBorder": true,
+			"roundedCorners": true,
+			"items": [
+				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Cover Mode Card"
+				}
+			]
+		},
+		{
+			"type": "Container",
 			"layouts": [
 				{}
 			],
@@ -11,7 +23,7 @@
 				{
 					"type": "TextBlock",
 					"size": "Large",
-					"text": "Potrait Image (Without fitMode)"
+					"text": "Potrait Image (Original Image)"
 				},
 				{
 					"type": "Image",
@@ -77,7 +89,7 @@
 				{
 					"type": "TextBlock",
 					"size": "Large",
-					"text": "Landscape Image (Without fitMode)"
+					"text": "Landscape Image (Original Image)"
 				},
 				{
 					"type": "Image",

--- a/samples/v1.5/Elements/Image.FitMode.Cover.json
+++ b/samples/v1.5/Elements/Image.FitMode.Cover.json
@@ -32,8 +32,6 @@
 		},
 		{
 			"type": "Container",
-			"showBorder": true,
-			"roundedCorners": true,
 			"items": [
 				{
 					"type": "Image",
@@ -98,8 +96,6 @@
 		},
 		{
 			"type": "Container",
-			"showBorder": true,
-			"roundedCorners": true,
 			"items": [
 				{
 					"type": "Image",

--- a/samples/v1.5/Elements/Image.FitMode.Fill.json
+++ b/samples/v1.5/Elements/Image.FitMode.Fill.json
@@ -14,178 +14,170 @@
 				}
 			]
 		},
+
 		{
 			"type": "Container",
-			"layouts": [
-				{
-					"type": "Layout.Flow"
-				}
-			],
 			"items": [
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "auto",
-							"width": "auto",
-							"fitMode": "fill"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Auto"
-						}
-					]
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "auto",
+					"width": "auto",
+					"fitMode": "fill"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "stretch",
-							"width": "stretch"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Stretch"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Auto"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "stretch",
+					"width": "stretch"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "100px",
-							"width": "300px",
-							"fitMode": "fill"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Landscape - 100px * 300px"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Stretch"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "100px",
+					"width": "300px",
+					"fitMode": "fill"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "200px",
-							"fitMode": "fill"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Portrait - 400px * 200px"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Landscape - 100px * 300px"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "400px",
+					"width": "200px",
+					"fitMode": "fill"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "300px",
-							"width": "300px"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Square - 300px * 300px"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Portrait - 400px * 200px"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
+					"height": "300px",
+					"width": "300px"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "auto",
-							"width": "auto"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Auto"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Square - 300px * 300px"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "auto",
+					"width": "auto"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "stretch",
-							"width": "stretch"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Stretch"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Auto"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "stretch",
+					"width": "stretch"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "200px",
-							"width": "300px"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Landscape - 200px * 300px"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Stretch"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "200px",
+					"width": "300px"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
-							"width": "200px"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Portrait - 400px * 200px"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Landscape - 200px * 300px"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "400px",
+					"width": "200px"
 				},
 				{
-					"type": "Container",
-					"items": [
-						{
-							"type": "Image",
-							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "300px",
-							"width": "300px"
-						},
-						{
-							"type": "TextBlock",
-							"size": "Large",
-							"text": "Fit Square - 300px * 300px"
-						}
-					]
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Portrait - 400px * 200px"
+				}
+			]
+		},
+		{
+			"type": "Container",
+			"items": [
+				{
+					"type": "Image",
+					"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
+					"height": "300px",
+					"width": "300px"
+				},
+				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fit Square - 300px * 300px"
 				}
 			]
 		}
+
 	]
 }

--- a/samples/v1.5/Elements/Image.FitMode.Fill.json
+++ b/samples/v1.5/Elements/Image.FitMode.Fill.json
@@ -4,6 +4,18 @@
 	"body": [
 		{
 			"type": "Container",
+			"showBorder": true,
+			"roundedCorners": true,
+			"items": [
+				{
+					"type": "TextBlock",
+					"size": "Large",
+					"text": "Fill Mode Card"
+				}
+			]
+		},
+		{
+			"type": "Container",
 			"layouts": [
 				{
 					"type": "Layout.Flow"
@@ -56,7 +68,7 @@
 						{
 							"type": "TextBlock",
 							"size": "Large",
-							"text": "Fit Landscape"
+							"text": "Fit Landscape - 100px * 300px"
 						}
 					]
 				},
@@ -73,7 +85,7 @@
 						{
 							"type": "TextBlock",
 							"size": "Large",
-							"text": "Fit Portrait"
+							"text": "Fit Portrait - 400px * 200px"
 						}
 					]
 				},
@@ -89,7 +101,7 @@
 						{
 							"type": "TextBlock",
 							"size": "Large",
-							"text": "Fit Square"
+							"text": "Fit Square - 300px * 300px"
 						}
 					]
 				},
@@ -137,7 +149,7 @@
 						{
 							"type": "TextBlock",
 							"size": "Large",
-							"text": "Fit Landscape"
+							"text": "Fit Landscape - 200px * 300px"
 						}
 					]
 				},
@@ -153,7 +165,7 @@
 						{
 							"type": "TextBlock",
 							"size": "Large",
-							"text": "Fit Portrait"
+							"text": "Fit Portrait - 400px * 200px"
 						}
 					]
 				},
@@ -163,13 +175,13 @@
 						{
 							"type": "Image",
 							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
-							"height": "400px",
+							"height": "300px",
 							"width": "300px"
 						},
 						{
 							"type": "TextBlock",
 							"size": "Large",
-							"text": "Fit Square"
+							"text": "Fit Square - 300px * 300px"
 						}
 					]
 				}

--- a/samples/v1.5/Elements/Image.FitMode.Fill.json
+++ b/samples/v1.5/Elements/Image.FitMode.Fill.json
@@ -17,7 +17,8 @@
 							"type": "Image",
 							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
 							"height": "auto",
-							"width": "auto"
+							"width": "auto",
+							"fitMode": "fill"
 						},
 						{
 							"type": "TextBlock",
@@ -48,8 +49,9 @@
 						{
 							"type": "Image",
 							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "200px",
-							"width": "400px"
+							"height": "100px",
+							"width": "300px",
+							"fitMode": "fill"
 						},
 						{
 							"type": "TextBlock",
@@ -65,7 +67,8 @@
 							"type": "Image",
 							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
 							"height": "400px",
-							"width": "200px"
+							"width": "200px",
+							"fitMode": "fill"
 						},
 						{
 							"type": "TextBlock",
@@ -80,8 +83,8 @@
 						{
 							"type": "Image",
 							"url": "https://th.bing.com/th/id/OIP.wlTpyLn8mhmAwuX9-lbcjwHaEO?w=267&h=180&c=7&r=0&o=5&dpr=1.5&pid=1.7",
-							"height": "400px",
-							"width": "400px"
+							"height": "300px",
+							"width": "300px"
 						},
 						{
 							"type": "TextBlock",
@@ -129,7 +132,7 @@
 							"type": "Image",
 							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
 							"height": "200px",
-							"width": "400px"
+							"width": "300px"
 						},
 						{
 							"type": "TextBlock",
@@ -161,7 +164,7 @@
 							"type": "Image",
 							"url": "https://cdn.pixabay.com/photo/2021/12/20/16/28/moose-6883432_1280.jpg",
 							"height": "400px",
-							"width": "400px"
+							"width": "300px"
 						},
 						{
 							"type": "TextBlock",

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/BaseActionElementRenderer.java
@@ -158,6 +158,24 @@ public abstract class BaseActionElementRenderer implements IBaseActionElementRen
         }
 
         /**
+         * Constructs an ActionOnClickListener. Use this constructor if you want to pass renderArgs also
+         * @param renderedCard
+         * @param baseActionElement
+         * @param cardActionHandler
+         * @param renderArgs
+         * @param isMenuAction - true if menu action(action in menuActions within another action), false otherwise
+         */
+        protected ActionOnClickListener(RenderedAdaptiveCard renderedCard,
+                                        BaseActionElement baseActionElement,
+                                        ICardActionHandler cardActionHandler,
+                                        RenderArgs renderArgs,
+                                        boolean isMenuAction)
+        {
+            this(renderedCard, baseActionElement, cardActionHandler, isMenuAction);
+            m_renderArgs = renderArgs;
+        }
+
+        /**
          * Constructs an ActionOnClickListener. Use this constructor if you want to support any type of action except ShowCardAction
          * @param renderedCard
          * @param baseActionElement

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionSetRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionSetRenderer.java
@@ -79,20 +79,7 @@ public class ActionSetRenderer extends BaseCardElementRenderer
 
         BaseActionElementVector baseActionElementList = actionSet.GetActions();
 
-        BaseActionElementVector baseActionElementFilteredList = new BaseActionElementVector();
-        // remove actions which are not supposed to be rendered inside popover
-        if (renderArgs.isPopoverContent()) {
-            List<ActionType> ignoreActions = List.of(ActionType.ToggleVisibility, ActionType.Popover, ActionType.ShowCard);
-            for (BaseActionElement actionElement : baseActionElementList)
-            {
-                if (!ignoreActions.contains(actionElement.GetElementType()))
-                {
-                    baseActionElementFilteredList.add(actionElement);
-                }
-            }
-        } else {
-            baseActionElementFilteredList = baseActionElementList;
-        }
+        BaseActionElementVector baseActionElementFilteredList = getActionElementsFilteredList(renderArgs, baseActionElementList);
 
         //Split Action Elements and render.
         Pair<BaseActionElementVector,BaseActionElementVector> actionElementVectorPair = Util.splitActionsByMode(baseActionElementFilteredList, hostConfig, renderedCard);
@@ -114,6 +101,24 @@ public class ActionSetRenderer extends BaseCardElementRenderer
 
         viewGroup.addView(rootLayout);
         return rootLayout;
+    }
+
+    public BaseActionElementVector getActionElementsFilteredList(RenderArgs renderArgs, BaseActionElementVector baseActionElementList) {
+        BaseActionElementVector baseActionElementFilteredList = new BaseActionElementVector();
+        if (renderArgs.isPopoverContent()) {
+            // remove actions which are not supposed to be rendered inside popover
+            List<ActionType> ignoreActions = List.of(ActionType.ToggleVisibility, ActionType.Popover, ActionType.ShowCard);
+            for (BaseActionElement actionElement : baseActionElementList)
+            {
+                if (!ignoreActions.contains(actionElement.GetElementType()))
+                {
+                    baseActionElementFilteredList.add(actionElement);
+                }
+            }
+        } else {
+            baseActionElementFilteredList = baseActionElementList;
+        }
+        return baseActionElementFilteredList;
     }
 
     private static ActionSetRenderer s_instance = null;

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -323,6 +323,7 @@ public class ImageRenderer extends BaseCardElementRenderer
                 break;
         }
 
+        // TODO :- Need to remove it before merging
         imageView.setBackgroundColor(Color.RED);
     }
 
@@ -391,14 +392,14 @@ public class ImageRenderer extends BaseCardElementRenderer
 
     @Override
     public ImageView render(
-        RenderedAdaptiveCard renderedCard,
-        Context context,
-        FragmentManager fragmentManager,
-        ViewGroup viewGroup,
-        BaseCardElement baseCardElement,
-        ICardActionHandler cardActionHandler,
-        HostConfig hostConfig,
-        RenderArgs renderArgs) throws Exception
+            RenderedAdaptiveCard renderedCard,
+            Context context,
+            FragmentManager fragmentManager,
+            ViewGroup viewGroup,
+            BaseCardElement baseCardElement,
+            ICardActionHandler cardActionHandler,
+            HostConfig hostConfig,
+            RenderArgs renderArgs) throws Exception
     {
         Image image = Util.castTo(baseCardElement, Image.class);
 

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -316,10 +316,10 @@ public class ImageRenderer extends BaseCardElementRenderer
                 imageView.setScaleType(ImageView.ScaleType.FIT_XY);
                 break;
             case Cover:
-                setImageInCoveAndContainrMode(imageView, image);
+                setImageInCoverAndContainMode(imageView, image);
                 break;
             case Contain:
-                setImageInCoveAndContainrMode(imageView, image);
+                setImageInCoverAndContainMode(imageView, image);
                 break;
         }
 
@@ -327,7 +327,7 @@ public class ImageRenderer extends BaseCardElementRenderer
         imageView.setBackgroundColor(Color.RED);
     }
 
-    private void setImageInCoveAndContainrMode(ImageView imageView, Image image) {
+    private void setImageInCoverAndContainMode(ImageView imageView, Image image) {
         imageView.setScaleType(ImageView.ScaleType.MATRIX);
 
         imageView.getViewTreeObserver().addOnGlobalLayoutListener(() -> {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -7,10 +7,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapShader;
 import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Shader;
-import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.os.AsyncTask;
 import android.text.TextUtils;
@@ -310,86 +308,6 @@ public class ImageRenderer extends BaseCardElementRenderer
         return backgroundColor;
     }
 
-    private void setImageFittingMode(ImageView imageView, Image image) {
-        switch (image.GetImageFitMode()) {
-            case Fill:
-                imageView.setScaleType(ImageView.ScaleType.FIT_XY);
-                break;
-            case Cover:
-                setImageInCoverAndContainMode(imageView, image);
-                break;
-            case Contain:
-                setImageInCoverAndContainMode(imageView, image);
-                break;
-        }
-
-        // TODO :- Need to remove it before merging
-        imageView.setBackgroundColor(Color.RED);
-    }
-
-    private void setImageInCoverAndContainMode(ImageView imageView, Image image) {
-        imageView.setScaleType(ImageView.ScaleType.MATRIX);
-
-        imageView.getViewTreeObserver().addOnGlobalLayoutListener(() -> {
-            Drawable drawable = imageView.getDrawable();
-            if (drawable == null) return;
-
-            float viewWidth = imageView.getWidth();
-            float viewHeight = imageView.getHeight();
-
-            int dWidth = drawable.getIntrinsicWidth();
-            int dHeight = drawable.getIntrinsicHeight();
-
-            float scale = 1.0f;
-            switch (image.GetImageFitMode()) {
-                case Cover:
-                    scale = Math.max(viewWidth / dWidth, viewHeight / dHeight);
-                    break;
-                case Contain:
-                    scale = Math.min(viewWidth / dWidth, viewHeight / dHeight);
-                    break;
-                default:
-                    return;
-            }
-
-            float scaledWidth = scale * dWidth;
-            float scaledHeight = scale * dHeight;
-
-            float dx = 0, dy = 0;
-
-            // Horizontal alignment
-            switch (image.GetHorizontalContentAlignment()) {
-                case Left:
-                    dx = 0;
-                    break;
-                case Center:
-                    dx = (viewWidth - scaledWidth) / 2f;
-                    break;
-                case Right:
-                    dx = viewWidth - scaledWidth;
-                    break;
-            }
-
-            // Vertical alignment
-            switch (image.GetVerticalContentAlignment()) {
-                case Top:
-                    dy = 0;
-                    break;
-                case Center:
-                    dy = (viewHeight - scaledHeight) / 2f;
-                    break;
-                case Bottom:
-                    dy = viewHeight - scaledHeight;
-                    break;
-            }
-
-            Matrix matrix = new Matrix();
-            matrix.setScale(scale, scale);
-            matrix.postTranslate(dx, dy);
-            imageView.setImageMatrix(matrix);
-        });
-    }
-
     @Override
     public ImageView render(
             RenderedAdaptiveCard renderedCard,
@@ -456,7 +374,7 @@ public class ImageRenderer extends BaseCardElementRenderer
         }
 
         imageView.setTag(tagContent);
-        setImageFittingMode(imageView, image);
+        ImageRendererKt.setImageFitMode(image, imageView);
         setVisibility(baseCardElement.GetIsVisible(), imageView);
 
         if (image.GetImageStyle() == ImageStyle.RoundedCorners) {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRendererKt.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRendererKt.kt
@@ -15,6 +15,10 @@ object ImageRendererKt {
 
     @JvmStatic
     fun setImageFitMode(image: Image, imageView: ImageView) {
+        if (image.GetPixelWidth() <= 0L || image.GetPixelHeight() <= 0L) {
+            return
+        }
+
         val imageFitMode = image.GetImageFitMode() ?: ImageFitMode.Fill
 
         if (imageFitMode == ImageFitMode.Fill) {

--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRendererKt.kt
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRendererKt.kt
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+package io.adaptivecards.renderer.readonly
+
+import android.graphics.Matrix
+import android.widget.ImageView
+import io.adaptivecards.objectmodel.HorizontalContentAlignment
+import io.adaptivecards.objectmodel.Image
+import io.adaptivecards.objectmodel.ImageFitMode
+import io.adaptivecards.objectmodel.VerticalContentAlignment
+import kotlin.math.max
+import kotlin.math.min
+
+object ImageRendererKt {
+
+    @JvmStatic
+    fun setImageFitMode(image: Image, imageView: ImageView) {
+        val imageFitMode = image.GetImageFitMode() ?: ImageFitMode.Fill
+
+        if (imageFitMode == ImageFitMode.Fill) {
+            imageView.scaleType = ImageView.ScaleType.FIT_XY
+            return
+        }
+
+        imageView.scaleType = ImageView.ScaleType.MATRIX
+        imageView.viewTreeObserver.addOnGlobalLayoutListener {
+            val drawable = imageView.drawable ?: return@addOnGlobalLayoutListener
+            val viewWidth = imageView.width.toFloat()
+            val viewHeight = imageView.height.toFloat()
+
+            val dWidth = drawable.intrinsicWidth
+            val dHeight = drawable.intrinsicHeight
+
+            val scale = when (image.GetImageFitMode()) {
+                ImageFitMode.Contain -> min((viewWidth / dWidth).toDouble(), (viewHeight / dHeight).toDouble())
+                    .toFloat()
+                ImageFitMode.Cover -> max((viewWidth / dWidth).toDouble(), (viewHeight / dHeight).toDouble())
+                    .toFloat()
+                else -> return@addOnGlobalLayoutListener
+            }
+
+            val scaledWidth = scale * dWidth
+            val scaledHeight = scale * dHeight
+
+            val dx = when (image.GetHorizontalContentAlignment() ?: HorizontalContentAlignment.Left) {
+                HorizontalContentAlignment.Left -> 0f
+                HorizontalContentAlignment.Center -> (viewWidth - scaledWidth) / 2f
+                HorizontalContentAlignment.Right -> viewWidth - scaledWidth
+            }
+            val dy = when (image.GetVerticalContentAlignment() ?: VerticalContentAlignment.Top) {
+                VerticalContentAlignment.Top -> 0f
+                VerticalContentAlignment.Center -> (viewHeight - scaledHeight) / 2f
+                VerticalContentAlignment.Bottom -> viewHeight - scaledHeight
+            }
+
+            val matrix = Matrix()
+            matrix.setScale(scale, scale)
+            matrix.postTranslate(dx, dy)
+            imageView.imageMatrix = matrix
+        }
+    }
+}

--- a/source/android/build.gradle
+++ b/source/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '1.9.24'
     repositories {
         google()
         mavenCentral()

--- a/source/shared/cpp/ObjectModel/Image.cpp
+++ b/source/shared/cpp/ObjectModel/Image.cpp
@@ -212,6 +212,11 @@ std::shared_ptr<BaseCardElement> ImageParser::DeserializeWithoutCheckingType(Par
     image->m_horizontalContentAlignment = ParseUtil::GetEnumValue<HorizontalContentAlignment>(json, AdaptiveCardSchemaKey::HorizontalContentAlignment, DEFAULT_HORIZONTAL_CONTENT_ALIGNMENT, HorizontalContentAlignmentFromString);
     image->m_verticalContentAlignment = ParseUtil::GetEnumValue<VerticalContentAlignment>(json, AdaptiveCardSchemaKey::VerticalContentAlignment, DEFAULT_VERTICAL_CONTENT_ALIGNMENT, VerticalContentAlignmentFromString);
 
+    // When fitMode is set to contain, the default style is always used
+    if (image->m_imageFitMode == ImageFitMode::Contain) {
+        image->SetImageStyle(ImageStyle::Default);
+    }
+
     const auto& widthDimension =
         ParseSizeForPixelSize(ParseUtil::GetString(json, AdaptiveCardSchemaKey::Width), &context.warnings);
     const auto& heightDimension =


### PR DESCRIPTION
#### Description
When an image is sized using both its width and height properties, it is stretched to cover its bounding box. This can cause the aspect ratio of the image to sometimes be lost.

#### Solution
Added properties to Image element.

1. "fitMode": "cover/fill/contain"
2. "verticalContentAlignment": "bottom/center/top"
3. "horizontalContentAlignment": "right/center/left" 

**In fitMode as fill, it takes full width and height and image aspect ratio is not maintained in this case.**
<img width="329" alt="Screenshot 2025-06-12 at 10 33 08 AM" src="https://github.com/user-attachments/assets/85f18887-53f3-4a0b-a318-25d3938c71f0" />

**In fitMode as cover, smaller dimension covers the full side and other side will get cropped.  Aspect ratio is maintained in this case.**
<img width="316" alt="Screenshot 2025-06-12 at 10 33 30 AM" src="https://github.com/user-attachments/assets/87df1634-97be-43c6-8784-082511ab1f27" />

**In fitMode as contain, larger dimension covers the full side and other side will have some empty space.  Aspect ratio is maintained in this case. Red color is shown just for testing purpose. It will be removed before merging.**
<img width="309" alt="Screenshot 2025-06-12 at 10 33 48 AM" src="https://github.com/user-attachments/assets/06dc598b-aee2-4743-9183-990e42a49c23" />


**Demo video showing fitMode with verticalContentAlignment and horizontalContentAlignment.**

https://github.com/user-attachments/assets/6dc531d7-c31c-46c4-ab69-c033be81523d


#### More Fit Mode Changes
1. Use fitMode only if both width and height is provided in pixels.
2. If imageFitmode is contain then ImageStyle will always be Default.

#### Other changes

1. Downgraded ext.kotlin_version to '1.9.24'.
2. Added one more constructor to pass renderArgs to BaseActionElementRenderer listener.




