### PR TITLE
[Android] Support 16 KB page support - Api 35

### DIFF
--- a/source/android/adaptivecards/build.gradle
+++ b/source/android/adaptivecards/build.gradle
@@ -43,7 +43,7 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
-    ndkVersion '23.1.7779620'
+    ndkVersion '28.0.13004108'
     lint {
         abortOnError false
     }


### PR DESCRIPTION

# Description

App need to support 16 KB page from API level 35.

We have upgraded ndk version to 28+ which by default handles 16 KB page. 


# How Verified

Tested all the cards in the visualizer app. Did not expect any crash. 