### PR TITLE
Implement safe key-value observation tracking with ACRStringBasedKeyValueObservation

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -409,6 +409,8 @@
 		CFF95C0D2982E3C900F321C3 /* ACOTypeaheadDynamicChoicesServiceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CFF95C0C2982E3C900F321C3 /* ACOTypeaheadDynamicChoicesServiceTests.mm */; };
 		CFF95C0F2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CFF95C0E2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm */; };
 		DD278A02932F65F8BDD1EA5D /* Pods_AdaptiveCards.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 255F5D3143215497D4067E21 /* Pods_AdaptiveCards.framework */; };
+		E67241702E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.m in Sources */ = {isa = PBXBuildFile; fileRef = E672416F2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.m */; };
+		E67241712E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h in Headers */ = {isa = PBXBuildFile; fileRef = E672416E2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h */; };
 		EC367F912F6036B68C5BBFDB /* Pods_AdaptiveCards_AdaptiveCardsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3DBB3CD3C02321AED9AEF65 /* Pods_AdaptiveCards_AdaptiveCardsTests.framework */; };
 		F401A8781F0DB69B006D7AF2 /* ACRImageSetUICollectionView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F401A8761F0DB69B006D7AF2 /* ACRImageSetUICollectionView.mm */; };
 		F401A87C1F0DCBC8006D7AF2 /* ACRImageSetRenderer.mm in Sources */ = {isa = PBXBuildFile; fileRef = F401A87A1F0DCBC8006D7AF2 /* ACRImageSetRenderer.mm */; };
@@ -1030,6 +1032,8 @@
 		CFF95C0C2982E3C900F321C3 /* ACOTypeaheadDynamicChoicesServiceTests.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = ACOTypeaheadDynamicChoicesServiceTests.mm; sourceTree = "<group>"; };
 		CFF95C0E2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = ACOTypeaheadDebouncerTests.mm; sourceTree = "<group>"; };
 		E3DBB3CD3C02321AED9AEF65 /* Pods_AdaptiveCards_AdaptiveCardsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdaptiveCards_AdaptiveCardsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E672416E2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ACRStringBasedKeyValueObservation.h; sourceTree = "<group>"; };
+		E672416F2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ACRStringBasedKeyValueObservation.m; sourceTree = "<group>"; };
 		ED131801E4C2E2B662925ABF /* Pods-AdaptiveCards-AdaptiveCardsTests.apprelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaptiveCards-AdaptiveCardsTests.apprelease.xcconfig"; path = "Target Support Files/Pods-AdaptiveCards-AdaptiveCardsTests/Pods-AdaptiveCards-AdaptiveCardsTests.apprelease.xcconfig"; sourceTree = "<group>"; };
 		F401A8761F0DB69B006D7AF2 /* ACRImageSetUICollectionView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRImageSetUICollectionView.mm; sourceTree = "<group>"; };
 		F401A8791F0DCBC8006D7AF2 /* ACRImageSetRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACRImageSetRenderer.h; sourceTree = "<group>"; };
@@ -1340,6 +1344,8 @@
 		6B92A71B266FE84F00CAE3BF /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				E672416E2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h */,
+				E672416F2E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.m */,
 				901FE9C72E04BDC800CD77C6 /* SwiftAdaptiveCardObjcBridge.h */,
 				901FE9C82E04BDC800CD77C6 /* SwiftAdaptiveCardObjcBridge.mm */,
 				901FE9C92E04BDC800CD77C6 /* SwiftAdaptiveCardSwiftBridge.swift */,
@@ -1656,6 +1662,14 @@
 			path = DynamicTypeahead;
 			sourceTree = "<group>";
 		};
+		E672416D2E6768B5000ECCE4 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				7AD18A8D2E0293DB00A35DDD /* FluentAssets.xcassets */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		F4071C751FCCBAEF00AF4FEA /* json */ = {
 			isa = PBXGroup;
 			children = (
@@ -1674,7 +1688,7 @@
 				F45A07191EF4BC44007C6503 /* Frameworks */,
 				F423C0B61EE1FBA900905679 /* Products */,
 				1779FD9986EE958A93BD0A28 /* Pods */,
-				7A2D17532DFA9A2C00E59055 /* Recovered References */,
+				E672416D2E6768B5000ECCE4 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2325,6 +2339,7 @@
 				CFF954D92981AF5800F321C3 /* ACRChoiceSetFilteredStyleView.h in Headers */,
 				6BFF240A2714E33000183C59 /* ACRToggleVisibilityTarget.h in Headers */,
 				6BFF23F22714C0F000183C59 /* ACORemoteResourceInformationPrivate.h in Headers */,
+				E67241712E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.h in Headers */,
 				6BFF23F82714C0F000183C59 /* ACRParseWarningPrivate.h in Headers */,
 				6BFF24062714E26900183C59 /* ACRToggleInputDataSource.h in Headers */,
 				6B377284260194000024E527 /* ACRActionExecuteRenderer.h in Headers */,
@@ -2823,6 +2838,7 @@
 				6B224278220BAC8B000ACDA1 /* BaseElement.cpp in Sources */,
 				6BDE5C4126FEA7DC003A1DDB /* ACROverflowTarget.mm in Sources */,
 				6B9D650F21095CBF00BB5C7B /* ACRMediaTarget.mm in Sources */,
+				E67241702E67690C000ECCE4 /* ACRStringBasedKeyValueObservation.m in Sources */,
 				6B8C765626449B09009548FA /* Table.cpp in Sources */,
 				4621E12E2BF35784004F03F3 /* RatingLabel.cpp in Sources */,
 				6B2242AF22334452000ACDA1 /* TextRun.cpp in Sources */,

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -301,7 +301,7 @@
                 [button addSubview:view];
                 // Only remove observer if one was actually added for this imageView
                 if ([rootView hasKVOObserverForImageView:view]) {
-                    [rootView removeObserverOnImageView:@"image" onObject:view keyToImageView:key];
+                    [rootView removeObserverOnImageViewForKeyPath:@"image" onObject:view keyToImageView:key];
                 }
                 [button setImageView:view.image withConfig:config];
             } else {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
@@ -11,8 +11,14 @@
 #import "ACRShowCardTarget.h"
 #import "ACRViewPrivate.h"
 #import "UtiliOS.h"
+#import "ACRStringBasedKeyValueObservation.h"
 
 NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
+
+@interface ACROverflowMenuItem ()
+/// KeyValueObservation tracking using NSMapTable with weak references to UIImageViews
+@property (nonatomic, strong, nonnull) NSMapTable<NSObject *, NSMutableArray<ACRStringBasedKeyValueObservation*> *> *observationsByObserver;
+@end
 
 @implementation ACROverflowMenuItem {
     __weak ACRView *_rootView;
@@ -21,15 +27,89 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
     void (^_onIconLoaded)(UIImage *);
 }
 
-+ (instancetype)initWithActionElement:(ACOBaseActionElement *)actionElement
-                               target:(NSObject<ACRSelectActionDelegate> *)target
-                             rootView:(ACRView *)rootView
++ (instancetype)overflowMenuItemWithActionElement:(ACOBaseActionElement *)actionElement
+                                           target:(NSObject<ACRSelectActionDelegate> *)target
+                                         rootView:(ACRView *)rootView
 {
     ACROverflowMenuItem *item = [[ACROverflowMenuItem alloc] init];
     item->_action = actionElement.element;
     item->_target = target;
     item->_rootView = rootView;
     return item;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _observationsByObserver = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsWeakMemory
+                                                        valueOptions:NSPointerFunctionsStrongMemory];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    // Clean up using safe KVO observation management
+    @synchronized(self.observationsByObserver) {
+        [self.observationsByObserver removeAllObjects];
+    }
+}
+
+// Safe KVO observation management
+- (void)startObserving:(nonnull NSObject *)object
+               keyPath:(nonnull NSString *)keyPath
+               options:(NSKeyValueObservingOptions)options
+               context:(nullable void *)context
+{
+    @synchronized(self.observationsByObserver) {
+        // Get or create the array of observations for this object
+        NSMutableArray<ACRStringBasedKeyValueObservation *> *objectObservations = [self.observationsByObserver objectForKey:object];
+        if (!objectObservations) {
+            objectObservations = [NSMutableArray array];
+            [self.observationsByObserver setObject:objectObservations forKey:object];
+        }
+
+        // Create the bridge that will call our observeValueForKeyPath method
+        __weak typeof(self) weakSelf = self;
+        ACRStringBasedKeyValueObservation *stringBasedKeyValueObservation = [[ACRStringBasedKeyValueObservation alloc] initWithObservableObject:object
+                                                                                                                                observedKeyPath:keyPath
+                                                                                                                                        options:options
+                                                                                                                                       callback:^(NSString * _Nullable keyPath, NSObject * _Nullable object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            // Call the original observeValueForKeyPath method
+            [strongSelf observeValueForKeyPath:keyPath
+                                      ofObject:object
+                                        change:change
+                                       context:context];
+        }];
+
+        [objectObservations addObject:stringBasedKeyValueObservation];
+    }
+}
+
+- (void)stopObserving:(nullable NSObject *)object {
+    if (!object) {
+        return;
+    }
+
+    @synchronized(self.observationsByObserver) {
+        NSMutableArray<ACRStringBasedKeyValueObservation *> *objectObservations = [self.observationsByObserver objectForKey:object];
+        if (!objectObservations || objectObservations.count == 0) {
+            return;
+        }
+
+        // Remove just the any observation from the array
+        ACRStringBasedKeyValueObservation *_Nullable stringBasedKeyValueObservation = [objectObservations firstObject];
+        if (stringBasedKeyValueObservation) {
+            [objectObservations removeObject:stringBasedKeyValueObservation];
+        }
+
+        // If no more observations for this object, remove the entry entirely
+        if (objectObservations.count == 0) {
+            [self.observationsByObserver removeObjectForKey:object];
+        }
+    }
 }
 
 - (NSString *)title
@@ -78,12 +158,10 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
             completion(view.image);
         } else {
             _onIconLoaded = completion;
-            [view addObserver:self
-                   forKeyPath:@"image"
-                      options:NSKeyValueObservingOptionNew
-                      context:_action.get()];
-            // Track that this imageView has a KVO observer
-            [_rootView addImageViewToKVOTracking:view];
+            [self startObserving:view
+                         keyPath:@"image"
+                         options:NSKeyValueObservingOptionNew
+                         context:_action.get()];
         }
     }
 }
@@ -99,7 +177,7 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
         if (_onIconLoaded) {
             _onIconLoaded(image);
         }
-        [object removeObserver:self forKeyPath:@"image"];
+        [self stopObserving:object];
     }
 }
 @end
@@ -141,9 +219,9 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
         // call buildTargetForButton since ACRShowCardTargetBuilder only responds to this callback
         // set nil button since the action is triggered from alert action not from a real button
         if (ACRRenderingStatus::ACROk == buildTargetForButton(director, action, nil, &target)) {
-            ACROverflowMenuItem *menuItem = [ACROverflowMenuItem initWithActionElement:action
-                                                                                target:target
-                                                                              rootView:_rootView];
+            ACROverflowMenuItem *menuItem = [ACROverflowMenuItem overflowMenuItemWithActionElement:action
+                                                                                            target:target
+                                                                                          rootView:_rootView];
             [_menuItems addObject:menuItem];
             UIAlertAction *menuAction = [UIAlertAction actionWithTitle:title
                                                                  style:UIAlertActionStyleDefault

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
@@ -99,7 +99,7 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
             return;
         }
 
-        // Remove just the any observation from the array
+        // Remove the first observation from the array
         ACRStringBasedKeyValueObservation *_Nullable stringBasedKeyValueObservation = [objectObservations firstObject];
         if (stringBasedKeyValueObservation) {
             [objectObservations removeObject:stringBasedKeyValueObservation];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
@@ -116,13 +116,10 @@ using namespace AdaptiveCards;
             ^(NSObject<ACOIResourceResolver> *imageResourceResolver, NSString *key, __unused std::shared_ptr<BaseCardElement> const &elem, NSURL *url, ACRView *root) {
                 UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
                 if (view) {
-                    [view addObserver:root
-                           forKeyPath:@"image"
-                              options:NSKeyValueObservingOptionNew
-                              context:backgroundImageProperties.get()];
-                    // Track that this imageView has a KVO observer
-                    [root addImageViewToKVOTracking:view];
-
+                    [root startObserving:view
+                                 keyPath:@"image"
+                                 options:NSKeyValueObservingOptionNew
+                                 context:backgroundImageProperties.get()];
                     // store the image view and card for easy retrieval in ACRView::observeValueForKeyPath
                     [root setImageView:key view:view];
                 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRStringBasedKeyValueObservation.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRStringBasedKeyValueObservation.h
@@ -1,0 +1,36 @@
+//
+//  ACRStringBasedKeyValueObservation.h
+//  AdaptiveCards
+//
+//  Copyright © 2025 Microsoft. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^ACRKeyValueObservationCallback)(NSString * _Nullable keyPath,
+                                              NSObject * _Nullable object,
+                                              NSDictionary<NSKeyValueChangeKey, id> * _Nullable change);
+
+/// A string-based Key-Value Observation subscriber
+/// Uses traditional string-based KVO approach with context pointer to uniquely identify each observer instance
+/// and automatically removes the observer on deallocation
+@interface ACRStringBasedKeyValueObservation : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Starts observing the specified keyPath on the given object with provided options
+/// - Parameters:
+///   - observableObject: The NSObject to observe
+///   - observedKeyPath: The keyPath string to observe (must be KVC compliant)
+///   - options: The NSKeyValueObservingOptions to specify what changes to observe
+///   - callback: The block to call when a change is observed
+- (instancetype)initWithObservableObject:(NSObject *)observableObject
+                         observedKeyPath:(NSString *)observedKeyPath
+                                 options:(NSKeyValueObservingOptions)options
+                                callback:(ACRKeyValueObservationCallback)callback;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRStringBasedKeyValueObservation.m
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRStringBasedKeyValueObservation.m
@@ -1,0 +1,60 @@
+//
+//  ACRStringBasedKeyValueObservation.m
+//  AdaptiveCards
+//
+//  Copyright © 2025 Microsoft. All rights reserved.
+//
+
+#import "ACRStringBasedKeyValueObservation.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ACRStringBasedKeyValueObservation ()
+/// observable object of interest
+@property (weak, nonatomic, nullable) NSObject *observableObject;
+/// observed keyPath of interest used to observe the object (must match the KVC compliant property name)
+@property (copy, nonatomic) NSString *observedKeyPath;
+/// Callback to handle Key-Value Observing notifications
+@property (copy, nonatomic) ACRKeyValueObservationCallback callback;
+@end
+
+@implementation ACRStringBasedKeyValueObservation
+
+- (instancetype)initWithObservableObject:(NSObject *)observableObject
+                         observedKeyPath:(NSString *)observedKeyPath
+                                 options:(NSKeyValueObservingOptions)options
+                                callback:(ACRKeyValueObservationCallback)callback {
+    self = [super init];
+    if (self) {
+        _observableObject = observableObject;
+        _observedKeyPath = [observedKeyPath copy];
+        _callback = [callback copy];
+
+        // Use self as unique context
+        [observableObject addObserver:self forKeyPath:observedKeyPath options:options context:(__bridge void *)self];
+    }
+    return self;
+}
+
+- (void)dealloc {
+    // Automatic cleanup when observer is deallocated
+    if (_observableObject) {
+        [_observableObject removeObserver:self forKeyPath:_observedKeyPath context:(__bridge void *)self];
+    }
+}
+
+- (void)observeValueForKeyPath:(NSString * _Nullable)keyPath
+                      ofObject:(id _Nullable)object
+                        change:(NSDictionary<NSKeyValueChangeKey,id> * _Nullable)change
+                       context:(void * _Nullable)context {
+    // Check if this notification is for this specific observer instance
+    if (context == (__bridge void *)self) {
+        self.callback(keyPath, object, change);
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
@@ -55,6 +55,4 @@
 
 - (BOOL)hasKVOObserverForImageView:(UIImageView *)imageView;
 
-- (void)addImageViewToKVOTracking:(UIImageView *)imageView;
-
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -750,7 +750,7 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
             return;
         }
 
-        // Remove just the any observation from the array
+        // Remove just the first observation from the array
         ACRStringBasedKeyValueObservation *_Nullable stringBasedKeyValueObservation = [objectObservations firstObject];
         if (stringBasedKeyValueObservation) {
             [objectObservations removeObject:stringBasedKeyValueObservation];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
@@ -42,14 +42,15 @@
 #import "UtiliOS.h"
 #import "CarouselPage.h"
 #import "Carousel.h"
+#import "ACRStringBasedKeyValueObservation.h"
 #import <AVFoundation/AVFoundation.h>
 
 using namespace AdaptiveCards;
 typedef UIImage * (^ImageLoadBlock)(NSURL *url);
 
 @interface ACRView ()
-// KVO observer tracking property (internal use only)
-@property (nonatomic, strong) NSMutableSet<UIImageView *> *imageViewsWithKVOObservers;
+/// KeyValueObservation tracking using NSMapTable with weak references to UIImageView
+@property (nonatomic, strong, nonnull) NSMapTable<NSObject *, NSMutableArray<ACRStringBasedKeyValueObservation*> *> *observationsByObserver;
 @end
 
 @implementation ACRView {
@@ -93,7 +94,8 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
         _imageContextMap = [[NSMutableDictionary alloc] init];
         _imageViewContextMap = [[NSMutableDictionary alloc] init];
         _setOfRemovedObservers = [[NSMutableSet alloc] init];
-        self.imageViewsWithKVOObservers = [[NSMutableSet alloc] init];
+        _observationsByObserver = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsWeakMemory
+                                                        valueOptions:NSPointerFunctionsStrongMemory];
         _paddingMap = [[NSMutableDictionary alloc] init];
         _inputHandlerLookupTable = [[NSMapTable alloc] initWithKeyOptions:NSMapTableWeakMemory valueOptions:NSMapTableWeakMemory capacity:5];
         _showcards = [[NSMutableArray alloc] init];
@@ -176,7 +178,14 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
 
 - (void)callDidLoadElementsIfNeeded
 {
-    // Call back app with didLoadElements
+    // Call back app with didLoadElements - check if all observations are completed
+    NSUInteger totalObservations = 0;
+    @synchronized(self.observationsByObserver) {
+        for (NSMutableArray *observations in [self.observationsByObserver objectEnumerator]) {
+            totalObservations += observations.count;
+        }
+    }
+
     if ([[self acrActionDelegate] respondsToSelector:@selector(didLoadElements)] && !_numberOfSubscribers && !_hasCalled) {
         _hasCalled = YES;
         [[self acrActionDelegate] didLoadElements];
@@ -264,12 +273,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
                     if (view) {
                         // check image already exists in the returned image view and register the image
                         [self registerImageFromUIImageView:view key:key];
-                        [view addObserver:self
-                               forKeyPath:@"image"
-                                  options:NSKeyValueObservingOptionNew
-                                  context:element.get()];
-                        // Track that this imageView has a KVO observer
-                        [self addImageViewToKVOTracking:view];
+                        [self startObserving:view
+                                     keyPath:@"image"
+                                     options:NSKeyValueObservingOptionNew
+                                     context:element.get()];
 
                         // store the image view and image element for easy retrieval in ACRView::observeValueForKeyPath
                         [rootView setImageView:key view:view];
@@ -292,12 +299,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
                         if (view) {
                             // check image already exists in the returned image view and register the image
                             [self registerImageFromUIImageView:view key:key];
-                            [view addObserver:self
-                                   forKeyPath:@"image"
-                                      options:NSKeyValueObservingOptionNew
-                                      context:element.get()];
-                            // Track that this imageView has a KVO observer
-                            [rootView addImageViewToKVOTracking:view];
+                            [self startObserving:view
+                                         keyPath:@"image"
+                                         options:NSKeyValueObservingOptionNew
+                                         context:element.get()];
 
                             // store the image view and image set element for easy retrieval in ACRView::observeValueForKeyPath
                             [rootView setImageView:key view:view];
@@ -326,12 +331,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
                             [self registerImageFromUIImageView:view key:key];
                             [contentholdingview addSubview:view];
                             contentholdingview.isMediaType = YES;
-                            [view addObserver:self
-                                   forKeyPath:@"image"
-                                      options:NSKeyValueObservingOptionNew
-                                      context:elem.get()];
-                            // Track that this imageView has a KVO observer
-                            [rootView addImageViewToKVOTracking:view];
+                            [self startObserving:view
+                                         keyPath:@"image"
+                                         options:NSKeyValueObservingOptionNew
+                                         context:elem.get()];
 
                             // store the image view and media element for easy retrieval in ACRView::observeValueForKeyPath
                             [rootView setImageView:key view:contentholdingview];
@@ -348,12 +351,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
                         if (view) {
                             // check image already exists in the returned image view and register the image
                             [self registerImageFromUIImageView:view key:key];
-                            [view addObserver:rootView
-                                   forKeyPath:@"image"
-                                      options:NSKeyValueObservingOptionNew
-                                      context:nil];
-                            // Track that this imageView has a KVO observer
-                            [rootView addImageViewToKVOTracking:view];
+                            [rootView startObserving:view
+                                             keyPath:@"image"
+                                             options:NSKeyValueObservingOptionNew
+                                             context:nil];
                             // store the image view for easy retrieval in ACRView::observeValueForKeyPath
                             [rootView setImageView:key view:view];
                         }
@@ -375,12 +376,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
                     ^(NSObject<ACOIResourceResolver> *imageResourceResolver, NSString *key, std::shared_ptr<BaseActionElement> const &element, NSURL *url, ACRView *rootView) {
                         UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
                         if (view) {
-                            [view addObserver:self
-                                   forKeyPath:@"image"
-                                      options:NSKeyValueObservingOptionNew
-                                      context:element.get()];
-                            // Track that this imageView has a KVO observer
-                            [rootView addImageViewToKVOTracking:view];
+                            [self startObserving:view
+                                         keyPath:@"image"
+                                         options:NSKeyValueObservingOptionNew
+                                         context:element.get()];
 
                             // store the image view for easy retrieval in ACRView::observeValueForKeyPath
                             [rootView setImageView:key view:view];
@@ -477,6 +476,7 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
                 [self loadBackgroundImageAccordingToResourceResolverIF:backgroundImageProperties key:nil observerAction:observerAction];
             }
             [self addBaseCardElementListToConcurrentQueue:carouselPage->GetItems() registration:registration];
+            break;
         }
             
         case AdaptiveCards::CardElementType::AdaptiveCard:
@@ -533,12 +533,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
                 ^(NSObject<ACOIResourceResolver> *imageResourceResolver, NSString *key, std::shared_ptr<BaseActionElement> const &elem, NSURL *url, ACRView *rootView) {
                     UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
                     if (view) {
-                        [view addObserver:self
-                               forKeyPath:@"image"
-                                  options:NSKeyValueObservingOptionNew
-                                  context:elem.get()];
-                        // Track that this imageView has a KVO observer
-                        [rootView addImageViewToKVOTracking:view];
+                        [self startObserving:view
+                                     keyPath:@"image"
+                                     options:NSKeyValueObservingOptionNew
+                                     context:elem.get()];
                         [rootView setImageView:key view:view];
                     }
                 };
@@ -700,38 +698,99 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
     }
 }
 
-// remove observer from UIImageView
-- (void)removeObserverOnImageView:(NSString *)KeyPath onObject:(NSObject *)object keyToImageView:(NSString *)key
+/// Start observing the given keyPath on the given object.
+/// - Parameters:
+///  - object: The object to observe.
+///  - keyPath: The keyPath to observe.
+///  - options: The options to use when observing.
+///  - context: The context to pass to the observer.
+- (void)startObserving:(nonnull NSObject *)object
+               keyPath:(nonnull NSString *)keyPath
+               options:(NSKeyValueObservingOptions)options
+               context:(nullable void *)context
 {
-    if ([object isKindOfClass:[UIImageView class]]) {
-        if (_imageViewContextMap[key]) {
-            [self removeObserver:self forKeyPath:KeyPath onObject:object];
+    @synchronized(self.observationsByObserver) {
+        // Get or create the array of observations for this object
+        NSMutableArray<ACRStringBasedKeyValueObservation *> *objectObservations = [self.observationsByObserver objectForKey:object];
+        if (!objectObservations) {
+            objectObservations = [NSMutableArray array];
+            [self.observationsByObserver setObject:objectObservations forKey:object];
+        }
+
+        // Create the bridge that will call our observeValueForKeyPath method
+        __weak typeof(self) weakSelf = self;
+        ACRStringBasedKeyValueObservation *stringBasedKeyValueObservation = [[ACRStringBasedKeyValueObservation alloc] initWithObservableObject:object
+                                                                                                        observedKeyPath:keyPath
+                                                                                                                options:options
+                                                                                                               callback:^(NSString * _Nullable keyPath, NSObject * _Nullable object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            // Call the original observeValueForKeyPath method
+            [strongSelf observeValueForKeyPath:keyPath
+                                      ofObject:object
+                                        change:change
+                                       context:context];
+        }];
+
+        [objectObservations addObject:stringBasedKeyValueObservation];
+    }
+}
+
+/// Stop observing the given object.
+/// - Parameters:
+///   - object: The object to stop observing. If nil, does nothing.
+/// - Note: This method removes only the first observation for the object (FIFO). If there are multiple observations for the same object, subsequent calls will remove them one by one.
+- (void)stopObserving:(nullable NSObject *)object {
+    if (!object) {
+        return;
+    }
+
+    @synchronized(self.observationsByObserver) {
+        NSMutableArray<ACRStringBasedKeyValueObservation *> *objectObservations = [self.observationsByObserver objectForKey:object];
+        if (!objectObservations || objectObservations.count == 0) {
+            return;
+        }
+
+        // Remove just the any observation from the array
+        ACRStringBasedKeyValueObservation *_Nullable stringBasedKeyValueObservation = [objectObservations firstObject];
+        if (stringBasedKeyValueObservation) {
+            [objectObservations removeObject:stringBasedKeyValueObservation];
+        }
+
+        // If no more observations for this object, remove the entry entirely
+        if (objectObservations.count == 0) {
+            [self.observationsByObserver removeObjectForKey:object];
         }
     }
 }
 
+// Legacy KVO interface methods for backward compatibility
 - (void)removeObserver:(NSObject *)observer forKeyPath:(NSString *)path onObject:(NSObject *)object
 {
     // check that makes sure that there are subscribers, and the given observer is not one of the removed observers
     if (_numberOfSubscribers && ![_setOfRemovedObservers containsObject:object]) {
         _numberOfSubscribers--;
-        [object removeObserver:self forKeyPath:path];
+        [self stopObserving:object];
         [_setOfRemovedObservers addObject:object];
         [self callDidLoadElementsIfNeeded];
     }
 }
 
-// KVO observer tracking
-- (BOOL)hasKVOObserverForImageView:(UIImageView *)imageView
-{
-    return [self.imageViewsWithKVOObservers containsObject:imageView];
+// Legacy KVO interface methods for backward compatibility
+- (BOOL)hasKVOObserverForImageView:(nonnull UIImageView *)imageView {
+    @synchronized(self.observationsByObserver) {
+        NSMutableArray<ACRStringBasedKeyValueObservation *> *observations = [self.observationsByObserver objectForKey:imageView];
+        return observations && observations.count > 0;
+    }
 }
 
-- (void)addImageViewToKVOTracking:(UIImageView *)imageView
+// Legacy KVO interface methods for backward compatibility
+- (void)removeObserverOnImageViewForKeyPath:(nonnull NSString *)keyPath onObject:(nonnull UIImageView *)object keyToImageView:(nonnull NSString *)key
 {
-    if (imageView && [imageView isKindOfClass:[UIImageView class]] && ![self hasKVOObserverForImageView:imageView])
-    {
-        [self.imageViewsWithKVOObservers addObject:imageView];
+    if ([object isKindOfClass:[UIImageView class]]) {
+        [self stopObserving:object];
+        if (_imageViewContextMap[key]) {
+            [_imageViewContextMap removeObjectForKey:key];
+        }
     }
 }
 
@@ -826,21 +885,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
 
 - (void)dealloc
 {
-    for (id key in _imageViewContextMap) {
-        id object = _imageViewContextMap[key];
-
-        if ([object isKindOfClass:[ACRContentHoldingUIView class]]) {
-            object = ((UIView *)object).subviews[0];
-        }
-
-        if (![_setOfRemovedObservers containsObject:object] && [object isKindOfClass:[UIImageView class]]) {
-            [object removeObserver:self forKeyPath:@"image"];
-        }
+    // Clean up using safe KVO observation management
+    @synchronized(self.observationsByObserver) {
+        [self.observationsByObserver removeAllObjects];
     }
-    
-    // Clean up KVO tracking set
-    [self.imageViewsWithKVOObservers removeAllObjects];
-    self.imageViewsWithKVOObservers = nil;
 }
 
 - (void)updatePaddingMap:(std::shared_ptr<StyledCollectionElement> const &)collection view:(UIView *)view

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
@@ -32,6 +32,11 @@
 #import <AdaptiveCards/StyledCollectionElement.h>
 #endif
 
+// Remove the following warning suppression and wrap the header content with NS_ASSUME_NONNULL_BEGIN/END
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+void RemoveMeAfterAddingMissingNullabilityAnnotationsInThisHeader(void * _Nullable);
+
 using namespace AdaptiveCards;
 
 @interface ACRView ()
@@ -62,7 +67,10 @@ typedef void (^ObserverActionBlockForBaseAction)(NSObject<ACOIResourceResolver> 
                                            key:(NSString *)key
                                 observerAction:(ObserverActionBlock)observerAction;
 
-- (void)removeObserverOnImageView:(NSString *)KeyPath onObject:(NSObject *)object keyToImageView:(NSString *)key;
+- (void)removeObserverOnImageViewForKeyPath:(NSString *)KeyPath onObject:(UIImageView *)object keyToImageView:(NSString *)key;
+
+// Safe KVO observation management
+- (void)startObserving:(nonnull NSObject *)object keyPath:(nonnull NSString *)keyPath options:(NSKeyValueObservingOptions)options context:(nullable void *)context;
 
 // KVO observer tracking
 - (BOOL)hasKVOObserverForImageView:(UIImageView *)imageView;
@@ -99,3 +107,5 @@ typedef void (^ObserverActionBlockForBaseAction)(NSObject<ACOIResourceResolver> 
 - (void)setContext:(ACORenderContext *)context;
 
 @end
+
+#pragma clang diagnostic pop

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -112,7 +112,7 @@ void renderBackgroundImage(const std::shared_ptr<AdaptiveCards::BackgroundImage>
     if ([key length]) {
         UIImageView *imgView = nil;
         UIImage *img = [rootView getImageMap][key];
-        if (img) {
+        if (img && [img isKindOfClass:[UIImage class]]) {
             switch (backgroundImage->GetFillMode()) {
                 case ImageFillMode::Repeat:
                 case ImageFillMode::RepeatHorizontally:
@@ -150,7 +150,7 @@ void renderBackgroundImage(const std::shared_ptr<AdaptiveCards::BackgroundImage>
 void renderBackgroundImage(ACRView *rootView, const BackgroundImage *backgroundImageProperties, UIImageView *imageView,
                            UIImage *image)
 {
-    if (rootView == nil || backgroundImageProperties == nullptr || imageView == nullptr || image == nullptr) {
+    if (rootView == nil || backgroundImageProperties == nullptr || imageView == nullptr || image == nullptr || ![image isKindOfClass:[UIImage class]]) {
         return;
     }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -438,14 +438,11 @@ ObserverActionBlock generateBackgroundImageObserverAction(
             __unused std::shared_ptr<BaseCardElement> const &elem, NSURL *url, ACRView *rootView) {
         UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
         if (view) {
-            [view addObserver:observer
-                   forKeyPath:@"image"
-                      options:NSKeyValueObservingOptionNew
-                      context:backgroundImageProperties.get()];
-            // Track that this imageView has a KVO observer
-            if ([observer isKindOfClass:[ACRView class]]) {
-                [((ACRView *)observer) addImageViewToKVOTracking:view];
-            }
+            // Use the new safe KVO method
+            [observer startObserving:view
+                             keyPath:@"image"
+                             options:NSKeyValueObservingOptionNew
+                             context:backgroundImageProperties.get()];
 
             // store the image view and column for easy retrieval in ACRView::observeValueForKeyPath
             [rootView setImageView:key view:view];

--- a/source/ios/AdaptiveCards/kvo-safe-observation-fix.patch
+++ b/source/ios/AdaptiveCards/kvo-safe-observation-fix.patch
@@ -1,0 +1,635 @@
+diff --git a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+index 81f98ec2..3b323bf8 100644
+--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
++++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+@@ -301,7 +301,7 @@
+                 [button addSubview:view];
+                 // Only remove observer if one was actually added for this imageView
+                 if ([rootView hasKVOObserverForImageView:view]) {
+-                    [rootView removeObserverOnImageView:@"image" onObject:view keyToImageView:key];
++                    [rootView removeObserverOnImageViewForKeyPath:@"image" onObject:view keyToImageView:key];
+                 }
+                 [button setImageView:view.image withConfig:config];
+             } else {
+diff --git a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
+index 6866f11c..c218534f 100644
+--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
++++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
+@@ -14,6 +14,11 @@
+ 
+ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
+ 
++@interface ACROverflowMenuItem ()
++/// KeyValueObservation tracking using NSMapTable with weak references to UIImageViews
++@property (nonatomic, strong, nonnull) NSMapTable<NSObject *, NSMutableArray<ACRStringBasedKeyValueObservation*> *> *observationsByObserver;
++@end
++
+ @implementation ACROverflowMenuItem {
+     __weak ACRView *_rootView;
+     std::shared_ptr<AdaptiveCards::BaseActionElement> _action;
+@@ -21,9 +26,9 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
+     void (^_onIconLoaded)(UIImage *);
+ }
+ 
+-+ (instancetype)initWithActionElement:(ACOBaseActionElement *)actionElement
+-                               target:(NSObject<ACRSelectActionDelegate> *)target
+-                             rootView:(ACRView *)rootView
+++ (instancetype)overflowMenuItemWithActionElement:(ACOBaseActionElement *)actionElement
++                                           target:(NSObject<ACRSelectActionDelegate> *)target
++                                         rootView:(ACRView *)rootView
+ {
+     ACROverflowMenuItem *item = [[ACROverflowMenuItem alloc] init];
+     item->_action = actionElement.element;
+@@ -32,6 +37,80 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
+     return item;
+ }
+ 
++- (instancetype)init
++{
++    self = [super init];
++    if (self) {
++        _observationsByObserver = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsWeakMemory
++                                                        valueOptions:NSPointerFunctionsStrongMemory];
++    }
++    return self;
++}
++
++- (void)dealloc
++{
++    // Clean up using safe KVO observation management
++    @synchronized(self.observationsByObserver) {
++        [self.observationsByObserver removeAllObjects];
++    }
++}
++
++// Safe KVO observation management
++- (void)startObserving:(nonnull NSObject *)object
++               keyPath:(nonnull NSString *)keyPath
++               options:(NSKeyValueObservingOptions)options
++               context:(nullable void *)context
++{
++    @synchronized(self.observationsByObserver) {
++        // Get or create the array of observations for this object
++        NSMutableArray<ACRStringBasedKeyValueObservation *> *objectObservations = [self.observationsByObserver objectForKey:object];
++        if (!objectObservations) {
++            objectObservations = [NSMutableArray array];
++            [self.observationsByObserver setObject:objectObservations forKey:object];
++        }
++
++        // Create the bridge that will call our observeValueForKeyPath method
++        __weak typeof(self) weakSelf = self;
++        ACRStringBasedKeyValueObservation *stringBasedKeyValueObservation = [[ACRStringBasedKeyValueObservation alloc] initWithObservableObject:object
++                                                                                                                                observedKeyPath:keyPath
++                                                                                                                                        options:options
++                                                                                                                                       callback:^(NSString * _Nullable keyPath, NSObject * _Nullable object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change) {
++            __strong typeof(weakSelf) strongSelf = weakSelf;
++            // Call the original observeValueForKeyPath method
++            [strongSelf observeValueForKeyPath:keyPath
++                                      ofObject:object
++                                        change:change
++                                       context:context];
++        }];
++
++        [objectObservations addObject:stringBasedKeyValueObservation];
++    }
++}
++
++- (void)stopObserving:(nullable NSObject *)object {
++    if (!object) {
++        return;
++    }
++
++    @synchronized(self.observationsByObserver) {
++        NSMutableArray<ACRStringBasedKeyValueObservation *> *objectObservations = [self.observationsByObserver objectForKey:object];
++        if (!objectObservations || objectObservations.count == 0) {
++            return;
++        }
++
++        // Remove just the any observation from the array
++        ACRStringBasedKeyValueObservation *_Nullable stringBasedKeyValueObservation = [objectObservations firstObject];
++        if (stringBasedKeyValueObservation) {
++            [objectObservations removeObject:stringBasedKeyValueObservation];
++        }
++
++        // If no more observations for this object, remove the entry entirely
++        if (objectObservations.count == 0) {
++            [self.observationsByObserver removeObjectForKey:object];
++        }
++    }
++}
++
+ - (NSString *)title
+ {
+     return [NSString stringWithUTF8String:_action->GetTitle().c_str()];
+@@ -78,12 +157,10 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
+             completion(view.image);
+         } else {
+             _onIconLoaded = completion;
+-            [view addObserver:self
+-                   forKeyPath:@"image"
+-                      options:NSKeyValueObservingOptionNew
+-                      context:_action.get()];
+-            // Track that this imageView has a KVO observer
+-            [_rootView addImageViewToKVOTracking:view];
++            [self startObserving:view
++                         keyPath:@"image"
++                         options:NSKeyValueObservingOptionNew
++                         context:_action.get()];
+         }
+     }
+ }
+@@ -99,7 +176,7 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
+         if (_onIconLoaded) {
+             _onIconLoaded(image);
+         }
+-        [object removeObserver:self forKeyPath:@"image"];
++        [self stopObserving:object];
+     }
+ }
+ @end
+@@ -141,9 +218,9 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
+         // call buildTargetForButton since ACRShowCardTargetBuilder only responds to this callback
+         // set nil button since the action is triggered from alert action not from a real button
+         if (ACRRenderingStatus::ACROk == buildTargetForButton(director, action, nil, &target)) {
+-            ACROverflowMenuItem *menuItem = [ACROverflowMenuItem initWithActionElement:action
+-                                                                                target:target
+-                                                                              rootView:_rootView];
++            ACROverflowMenuItem *menuItem = [ACROverflowMenuItem overflowMenuItemWithActionElement:action
++                                                                                            target:target
++                                                                                          rootView:_rootView];
+             [_menuItems addObject:menuItem];
+             UIAlertAction *menuAction = [UIAlertAction actionWithTitle:title
+                                                                  style:UIAlertActionStyleDefault
+diff --git a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+index 1a4ee232..59b60b7b 100644
+--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
++++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRenderer.mm
+@@ -116,13 +116,10 @@ using namespace AdaptiveCards;
+             ^(NSObject<ACOIResourceResolver> *imageResourceResolver, NSString *key, __unused std::shared_ptr<BaseCardElement> const &elem, NSURL *url, ACRView *root) {
+                 UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
+                 if (view) {
+-                    [view addObserver:root
+-                           forKeyPath:@"image"
+-                              options:NSKeyValueObservingOptionNew
+-                              context:backgroundImageProperties.get()];
+-                    // Track that this imageView has a KVO observer
+-                    [root addImageViewToKVOTracking:view];
+-
++                    [root startObserving:view
++                                 keyPath:@"image"
++                                 options:NSKeyValueObservingOptionNew
++                                 context:backgroundImageProperties.get()];
+                     // store the image view and card for easy retrieval in ACRView::observeValueForKeyPath
+                     [root setImageView:key view:view];
+                 }
+diff --git a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+index f080e5cc..a5b71b2a 100644
+--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
++++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.h
+@@ -55,6 +55,4 @@
+ 
+ - (BOOL)hasKVOObserverForImageView:(UIImageView *)imageView;
+ 
+-- (void)addImageViewToKVOTracking:(UIImageView *)imageView;
+-
+ @end
+diff --git a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+index cd6ff659..46980eb0 100644
+--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
++++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRView.mm
+@@ -48,8 +48,8 @@ using namespace AdaptiveCards;
+ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+ 
+ @interface ACRView ()
+-// KVO observer tracking property (internal use only)
+-@property (nonatomic, strong) NSMutableSet<UIImageView *> *imageViewsWithKVOObservers;
++/// KeyValueObservation tracking using NSMapTable with weak references to UIImageView
++@property (nonatomic, strong, nonnull) NSMapTable<NSObject *, NSMutableArray<ACRStringBasedKeyValueObservation*> *> *observationsByObserver;
+ @end
+ 
+ @implementation ACRView {
+@@ -93,7 +93,8 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+         _imageContextMap = [[NSMutableDictionary alloc] init];
+         _imageViewContextMap = [[NSMutableDictionary alloc] init];
+         _setOfRemovedObservers = [[NSMutableSet alloc] init];
+-        self.imageViewsWithKVOObservers = [[NSMutableSet alloc] init];
++        _observationsByObserver = [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsWeakMemory
++                                                        valueOptions:NSPointerFunctionsStrongMemory];
+         _paddingMap = [[NSMutableDictionary alloc] init];
+         _inputHandlerLookupTable = [[NSMapTable alloc] initWithKeyOptions:NSMapTableWeakMemory valueOptions:NSMapTableWeakMemory capacity:5];
+         _showcards = [[NSMutableArray alloc] init];
+@@ -176,7 +177,14 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+ 
+ - (void)callDidLoadElementsIfNeeded
+ {
+-    // Call back app with didLoadElements
++    // Call back app with didLoadElements - check if all observations are completed
++    NSUInteger totalObservations = 0;
++    @synchronized(self.observationsByObserver) {
++        for (NSMutableArray *observations in [self.observationsByObserver objectEnumerator]) {
++            totalObservations += observations.count;
++        }
++    }
++
+     if ([[self acrActionDelegate] respondsToSelector:@selector(didLoadElements)] && !_numberOfSubscribers && !_hasCalled) {
+         _hasCalled = YES;
+         [[self acrActionDelegate] didLoadElements];
+@@ -264,12 +272,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+                     if (view) {
+                         // check image already exists in the returned image view and register the image
+                         [self registerImageFromUIImageView:view key:key];
+-                        [view addObserver:self
+-                               forKeyPath:@"image"
+-                                  options:NSKeyValueObservingOptionNew
+-                                  context:element.get()];
+-                        // Track that this imageView has a KVO observer
+-                        [self addImageViewToKVOTracking:view];
++                        [self startObserving:view
++                                     keyPath:@"image"
++                                     options:NSKeyValueObservingOptionNew
++                                     context:element.get()];
+ 
+                         // store the image view and image element for easy retrieval in ACRView::observeValueForKeyPath
+                         [rootView setImageView:key view:view];
+@@ -292,12 +298,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+                         if (view) {
+                             // check image already exists in the returned image view and register the image
+                             [self registerImageFromUIImageView:view key:key];
+-                            [view addObserver:self
+-                                   forKeyPath:@"image"
+-                                      options:NSKeyValueObservingOptionNew
+-                                      context:element.get()];
+-                            // Track that this imageView has a KVO observer
+-                            [rootView addImageViewToKVOTracking:view];
++                            [self startObserving:view
++                                         keyPath:@"image"
++                                         options:NSKeyValueObservingOptionNew
++                                         context:element.get()];
+ 
+                             // store the image view and image set element for easy retrieval in ACRView::observeValueForKeyPath
+                             [rootView setImageView:key view:view];
+@@ -326,12 +330,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+                             [self registerImageFromUIImageView:view key:key];
+                             [contentholdingview addSubview:view];
+                             contentholdingview.isMediaType = YES;
+-                            [view addObserver:self
+-                                   forKeyPath:@"image"
+-                                      options:NSKeyValueObservingOptionNew
+-                                      context:elem.get()];
+-                            // Track that this imageView has a KVO observer
+-                            [rootView addImageViewToKVOTracking:view];
++                            [self startObserving:view
++                                         keyPath:@"image"
++                                         options:NSKeyValueObservingOptionNew
++                                         context:elem.get()];
+ 
+                             // store the image view and media element for easy retrieval in ACRView::observeValueForKeyPath
+                             [rootView setImageView:key view:contentholdingview];
+@@ -348,12 +350,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+                         if (view) {
+                             // check image already exists in the returned image view and register the image
+                             [self registerImageFromUIImageView:view key:key];
+-                            [view addObserver:rootView
+-                                   forKeyPath:@"image"
+-                                      options:NSKeyValueObservingOptionNew
+-                                      context:nil];
+-                            // Track that this imageView has a KVO observer
+-                            [rootView addImageViewToKVOTracking:view];
++                            [rootView startObserving:view
++                                             keyPath:@"image"
++                                             options:NSKeyValueObservingOptionNew
++                                             context:nil];
+                             // store the image view for easy retrieval in ACRView::observeValueForKeyPath
+                             [rootView setImageView:key view:view];
+                         }
+@@ -375,12 +375,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+                     ^(NSObject<ACOIResourceResolver> *imageResourceResolver, NSString *key, std::shared_ptr<BaseActionElement> const &element, NSURL *url, ACRView *rootView) {
+                         UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
+                         if (view) {
+-                            [view addObserver:self
+-                                   forKeyPath:@"image"
+-                                      options:NSKeyValueObservingOptionNew
+-                                      context:element.get()];
+-                            // Track that this imageView has a KVO observer
+-                            [rootView addImageViewToKVOTracking:view];
++                            [self startObserving:view
++                                         keyPath:@"image"
++                                         options:NSKeyValueObservingOptionNew
++                                         context:element.get()];
+ 
+                             // store the image view for easy retrieval in ACRView::observeValueForKeyPath
+                             [rootView setImageView:key view:view];
+@@ -477,6 +475,7 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+                 [self loadBackgroundImageAccordingToResourceResolverIF:backgroundImageProperties key:nil observerAction:observerAction];
+             }
+             [self addBaseCardElementListToConcurrentQueue:carouselPage->GetItems() registration:registration];
++            break;
+         }
+             
+         case AdaptiveCards::CardElementType::AdaptiveCard:
+@@ -533,12 +532,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+                 ^(NSObject<ACOIResourceResolver> *imageResourceResolver, NSString *key, std::shared_ptr<BaseActionElement> const &elem, NSURL *url, ACRView *rootView) {
+                     UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
+                     if (view) {
+-                        [view addObserver:self
+-                               forKeyPath:@"image"
+-                                  options:NSKeyValueObservingOptionNew
+-                                  context:elem.get()];
+-                        // Track that this imageView has a KVO observer
+-                        [rootView addImageViewToKVOTracking:view];
++                        [self startObserving:view
++                                     keyPath:@"image"
++                                     options:NSKeyValueObservingOptionNew
++                                     context:elem.get()];
+                         [rootView setImageView:key view:view];
+                     }
+                 };
+@@ -700,38 +697,99 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+     }
+ }
+ 
+-// remove observer from UIImageView
+-- (void)removeObserverOnImageView:(NSString *)KeyPath onObject:(NSObject *)object keyToImageView:(NSString *)key
+-{
+-    if ([object isKindOfClass:[UIImageView class]]) {
+-        if (_imageViewContextMap[key]) {
+-            [self removeObserver:self forKeyPath:KeyPath onObject:object];
++/// Start observing the given keyPath on the given object.
++/// - Parameters:
++///  - object: The object to observe.
++///  - keyPath: The keyPath to observe.
++///  - options: The options to use when observing.
++///  - context: The context to pass to the observer.
++- (void)startObserving:(nonnull NSObject *)object
++               keyPath:(nonnull NSString *)keyPath
++               options:(NSKeyValueObservingOptions)options
++               context:(nullable void *)context
++{
++    @synchronized(self.observationsByObserver) {
++        // Get or create the array of observations for this object
++        NSMutableArray<ACRStringBasedKeyValueObservation *> *objectObservations = [self.observationsByObserver objectForKey:object];
++        if (!objectObservations) {
++            objectObservations = [NSMutableArray array];
++            [self.observationsByObserver setObject:objectObservations forKey:object];
++        }
++
++        // Create the bridge that will call our observeValueForKeyPath method
++        __weak typeof(self) weakSelf = self;
++        ACRStringBasedKeyValueObservation *stringBasedKeyValueObservation = [[ACRStringBasedKeyValueObservation alloc] initWithObservableObject:object
++                                                                                                        observedKeyPath:keyPath
++                                                                                                                options:options
++                                                                                                               callback:^(NSString * _Nullable keyPath, NSObject * _Nullable object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change) {
++            __strong typeof(weakSelf) strongSelf = weakSelf;
++            // Call the original observeValueForKeyPath method
++            [strongSelf observeValueForKeyPath:keyPath
++                                      ofObject:object
++                                        change:change
++                                       context:context];
++        }];
++
++        [objectObservations addObject:stringBasedKeyValueObservation];
++    }
++}
++
++/// Stop observing the given object.
++/// - Parameters:
++///   - object: The object to stop observing. If nil, does nothing.
++/// - Note: This method removes only the first observation for the object (FIFO). If there are multiple observations for the same object, subsequent calls will remove them one by one.
++- (void)stopObserving:(nullable NSObject *)object {
++    if (!object) {
++        return;
++    }
++
++    @synchronized(self.observationsByObserver) {
++        NSMutableArray<ACRStringBasedKeyValueObservation *> *objectObservations = [self.observationsByObserver objectForKey:object];
++        if (!objectObservations || objectObservations.count == 0) {
++            return;
++        }
++
++        // Remove just the any observation from the array
++        ACRStringBasedKeyValueObservation *_Nullable stringBasedKeyValueObservation = [objectObservations firstObject];
++        if (stringBasedKeyValueObservation) {
++            [objectObservations removeObject:stringBasedKeyValueObservation];
++        }
++
++        // If no more observations for this object, remove the entry entirely
++        if (objectObservations.count == 0) {
++            [self.observationsByObserver removeObjectForKey:object];
+         }
+     }
+ }
+ 
++// Legacy KVO interface methods for backward compatibility
+ - (void)removeObserver:(NSObject *)observer forKeyPath:(NSString *)path onObject:(NSObject *)object
+ {
+     // check that makes sure that there are subscribers, and the given observer is not one of the removed observers
+     if (_numberOfSubscribers && ![_setOfRemovedObservers containsObject:object]) {
+         _numberOfSubscribers--;
+-        [object removeObserver:self forKeyPath:path];
++        [self stopObserving:object];
+         [_setOfRemovedObservers addObject:object];
+         [self callDidLoadElementsIfNeeded];
+     }
+ }
+ 
+-// KVO observer tracking
+-- (BOOL)hasKVOObserverForImageView:(UIImageView *)imageView
+-{
+-    return [self.imageViewsWithKVOObservers containsObject:imageView];
++// Legacy KVO interface methods for backward compatibility
++- (BOOL)hasKVOObserverForImageView:(nonnull UIImageView *)imageView {
++    @synchronized(self.observationsByObserver) {
++        NSMutableArray<ACRStringBasedKeyValueObservation *> *observations = [self.observationsByObserver objectForKey:imageView];
++        return observations && observations.count > 0;
++    }
+ }
+ 
+-- (void)addImageViewToKVOTracking:(UIImageView *)imageView
++// Legacy KVO interface methods for backward compatibility
++- (void)removeObserverOnImageViewForKeyPath:(nonnull NSString *)keyPath onObject:(nonnull UIImageView *)object keyToImageView:(nonnull NSString *)key
+ {
+-    if (imageView && [imageView isKindOfClass:[UIImageView class]] && ![self hasKVOObserverForImageView:imageView])
+-    {
+-        [self.imageViewsWithKVOObservers addObject:imageView];
++    if ([object isKindOfClass:[UIImageView class]]) {
++        [self stopObserving:object];
++        if (_imageViewContextMap[key]) {
++            [_imageViewContextMap removeObjectForKey:key];
++        }
+     }
+ }
+ 
+@@ -826,21 +884,10 @@ typedef UIImage * (^ImageLoadBlock)(NSURL *url);
+ 
+ - (void)dealloc
+ {
+-    for (id key in _imageViewContextMap) {
+-        id object = _imageViewContextMap[key];
+-
+-        if ([object isKindOfClass:[ACRContentHoldingUIView class]]) {
+-            object = ((UIView *)object).subviews[0];
+-        }
+-
+-        if (![_setOfRemovedObservers containsObject:object] && [object isKindOfClass:[UIImageView class]]) {
+-            [object removeObserver:self forKeyPath:@"image"];
+-        }
++    // Clean up using safe KVO observation management
++    @synchronized(self.observationsByObserver) {
++        [self.observationsByObserver removeAllObjects];
+     }
+-    
+-    // Clean up KVO tracking set
+-    [self.imageViewsWithKVOObservers removeAllObjects];
+-    self.imageViewsWithKVOObservers = nil;
+ }
+ 
+ - (void)updatePaddingMap:(std::shared_ptr<StyledCollectionElement> const &)collection view:(UIView *)view
+diff --git a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
+index 5d914337..08293bb3 100644
+--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
++++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACRViewPrivate.h
+@@ -32,6 +32,11 @@
+ #import <AdaptiveCards/StyledCollectionElement.h>
+ #endif
+ 
++// Remove the following warning suppression and wrap the header content with NS_ASSUME_NONNULL_BEGIN/END
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wnullability-completeness"
++void RemoveMeAfterAddingMissingNullabilityAnnotationsInThisHeader(void * _Nullable);
++
+ using namespace AdaptiveCards;
+ 
+ @interface ACRView ()
+@@ -62,7 +67,10 @@ typedef void (^ObserverActionBlockForBaseAction)(NSObject<ACOIResourceResolver>
+                                            key:(NSString *)key
+                                 observerAction:(ObserverActionBlock)observerAction;
+ 
+-- (void)removeObserverOnImageView:(NSString *)KeyPath onObject:(NSObject *)object keyToImageView:(NSString *)key;
++- (void)removeObserverOnImageViewForKeyPath:(NSString *)KeyPath onObject:(UIImageView *)object keyToImageView:(NSString *)key;
++
++// Safe KVO observation management
++- (void)startObserving:(nonnull NSObject *)object keyPath:(nonnull NSString *)keyPath options:(NSKeyValueObservingOptions)options context:(nullable void *)context;
+ 
+ // KVO observer tracking
+ - (BOOL)hasKVOObserverForImageView:(UIImageView *)imageView;
+@@ -99,3 +107,5 @@ typedef void (^ObserverActionBlockForBaseAction)(NSObject<ACOIResourceResolver>
+ - (void)setContext:(ACORenderContext *)context;
+ 
+ @end
++
++#pragma clang diagnostic pop
+diff --git a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
+index b7dbd491..28c469a6 100644
+--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
++++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/UtiliOS.h
+@@ -202,3 +202,30 @@ NSString *stringForCString(const std::optional<std::string> cString);
+ //CDN URL for icon path
+ NSString *cdnURLForIcon(NSString *iconPath);
+ 
++NS_ASSUME_NONNULL_BEGIN
++
++typedef void (^ACRKeyValueObservationCallback)(NSString * _Nullable keyPath,
++                                              NSObject * _Nullable object,
++                                              NSDictionary<NSKeyValueChangeKey, id> * _Nullable change);
++
++/// A string-based Key-Value Observation subscriber
++/// Uses traditional string-based KVO approach with context pointer to uniquely identify each observer instance
++/// and automatically removes the observer on deallocation
++@interface ACRStringBasedKeyValueObservation : NSObject
++
++- (instancetype)init NS_UNAVAILABLE;
++
++/// Starts observing the specified keyPath on the given object with provided options
++/// - Parameters:
++///   - observableObject: The NSObject to observe
++///   - observedKeyPath: The keyPath string to observe (must be KVC compliant)
++///   - options: The NSKeyValueObservingOptions to specify what changes to observe
++///   - callback: The block to call when a change is observed
++- (instancetype)initWithObservableObject:(NSObject *)observableObject
++                         observedKeyPath:(NSString *)observedKeyPath
++                                 options:(NSKeyValueObservingOptions)options
++                                callback:(ACRKeyValueObservationCallback)callback;
++
++@end
++
++NS_ASSUME_NONNULL_END
+diff --git a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+index 5a4cd9bf..47184941 100644
+--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
++++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+@@ -438,14 +438,11 @@ ObserverActionBlock generateBackgroundImageObserverAction(
+             __unused std::shared_ptr<BaseCardElement> const &elem, NSURL *url, ACRView *rootView) {
+         UIImageView *view = [imageResourceResolver resolveImageViewResource:url];
+         if (view) {
+-            [view addObserver:observer
+-                   forKeyPath:@"image"
+-                      options:NSKeyValueObservingOptionNew
+-                      context:backgroundImageProperties.get()];
+-            // Track that this imageView has a KVO observer
+-            if ([observer isKindOfClass:[ACRView class]]) {
+-                [((ACRView *)observer) addImageViewToKVOTracking:view];
+-            }
++            // Use the new safe KVO method
++            [observer startObserving:view
++                             keyPath:@"image"
++                             options:NSKeyValueObservingOptionNew
++                             context:backgroundImageProperties.get()];
+ 
+             // store the image view and column for easy retrieval in ACRView::observeValueForKeyPath
+             [rootView setImageView:key view:view];
+@@ -1418,3 +1415,55 @@ NSString *cdnURLForIcon(NSString *iconPath)
+     NSString const *CDNPath = [featureFlagResolver stringForFlag:@"fluentIconCdnURL"] ?: baseFluentIconCDNURL;
+     return [[NSString alloc] initWithFormat:@"%@%@",CDNPath, iconPath];
+ }
++
++NS_ASSUME_NONNULL_BEGIN
++
++@interface ACRStringBasedKeyValueObservation ()
++/// observable object of interest
++@property (weak, nonatomic, nullable) NSObject *observableObject;
++/// observed keyPath of interest used to observe the object (must match the KVC compliant property name)
++@property (copy, nonatomic) NSString *observedKeyPath;
++/// Callback to handle Key-Value Observing notifications
++@property (copy, nonatomic) ACRKeyValueObservationCallback callback;
++@end
++
++@implementation ACRStringBasedKeyValueObservation
++
++- (instancetype)initWithObservableObject:(NSObject *)observableObject
++                         observedKeyPath:(NSString *)observedKeyPath
++                                 options:(NSKeyValueObservingOptions)options
++                                callback:(ACRKeyValueObservationCallback)callback {
++    self = [super init];
++    if (self) {
++        _observableObject = observableObject;
++        _observedKeyPath = [observedKeyPath copy];
++        _callback = [callback copy];
++
++        // Use self as unique context
++        [observableObject addObserver:self forKeyPath:observedKeyPath options:options context:(__bridge void *)self];
++    }
++    return self;
++}
++
++- (void)dealloc {
++    // Automatic cleanup when observer is deallocated
++    if (_observableObject) {
++        [_observableObject removeObserver:self forKeyPath:_observedKeyPath context:(__bridge void *)self];
++    }
++}
++
++- (void)observeValueForKeyPath:(NSString * _Nullable)keyPath
++                      ofObject:(id _Nullable)object
++                        change:(NSDictionary<NSKeyValueChangeKey,id> * _Nullable)change
++                       context:(void * _Nullable)context {
++    // Check if this notification is for this specific observer instance
++    if (context == (__bridge void *)self) {
++        self.callback(keyPath, object, change);
++    } else {
++        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
++    }
++}
++
++@end
++
++NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Related Issue

KeyValue Observation crasher

# Description

- Add ACRStringBasedKeyValueObservation wrapper for automatic KVO cleanup
- Replace manual KVO observer management with NSMapTable-based tracking
- Integrate subscriber counting and removal guards with new safe system 
- Update all KVO observation calls to use new startObserving/stopObserving methods 
- Add dual protection: crash prevention + logical error prevention
- Maintain backward compatibility with legacy KVO interface methods 
- Fix KVO crashes caused by missing observeValueForKeyPath implementations 
- Enhance ACROverflowMenuItem with safe KVO observation management
- Additional UIImage class check as NSNull can exist in the imageViewMap mutable dictionary from ACRView.mm

This addresses KVO-related crashes in Teams Adaptive Cards Mobile v6.22.1 triggered by carousel SDK updates that increased notification frequency, exposing underlying observer pattern bugs in TSAnimatedImageView components.

The new system provides:
- Automatic observer cleanup in dealloc (prevents crashes)
- Thread-safe observation tracking with weak references
- Subscriber counting for completion callbacks
- Removal guards to prevent double-removal errors
- Generic NSObject support beyond UIImageView


# How Verified

How you verified the fix, including one or all of the following:
1. Run all existing unit tests and UITests

3. run manual screenshot tests

<img width="25%" height="50%" alt="Simulator Screenshot - iPhone 16e - 2025-09-03 at 20 54 08" src="https://github.com/user-attachments/assets/f3fdda26-15ef-46e2-ba37-f3936a677cbf" />
<img width="25%" height="50%" alt="Simulator Screenshot - iPhone 16e - 2025-09-03 at 20 54 20" src="https://github.com/user-attachments/assets/3cb833f7-1ca2-47b9-9848-52a5cc927024" />
<img width="25%" height="50%" alt="Simulator Screenshot - iPhone 16e - 2025-09-03 at 20 54 42" src="https://github.com/user-attachments/assets/4beb41f1-196b-47f5-b4b0-20a0e3fcd46a" />
<img width="25%" height="50%" alt="Simulator Screenshot - iPhone 16e - 2025-09-03 at 20 55 23" src="https://github.com/user-attachments/assets/b5ee9eb7-9baf-422f-bd1d-cc42c3cc60e7" />
<img width="25%" height="50%" alt="Simulator Screenshot - iPhone 16e - 2025-09-03 at 20 55 28" src="https://github.com/user-attachments/assets/f3166fa2-821f-4b0a-91be-43166de22677" />
