### PR TITLE
fix(visionOS): guard keyboardDismissMode, unavailable on visionOS

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetViewController.mm
@@ -189,7 +189,9 @@
     UIScrollView *scrollView = [[UIScrollView alloc] init];
     scrollView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:scrollView];
+#if !TARGET_OS_VISION
     scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+#endif
     self.scrollView = scrollView;
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.scrollView addSubview:self.contentView];


### PR DESCRIPTION
### What

`UIScrollView.keyboardDismissMode` is declared `API_UNAVAILABLE(visionos)` in the XROS SDK:

```
XROS26.2.sdk/System/Library/Frameworks/UIKit.framework/Headers/UIScrollView.h:284
@property(nonatomic) UIScrollViewKeyboardDismissMode keyboardDismissMode
    API_AVAILABLE(ios(7.0)) API_UNAVAILABLE(visionos);
```

`ACRBottomSheetViewController.setupScrollView` assigns it unconditionally, so any consumer
that archives AdaptiveCards for `xros` / `xrsimulator` fails to compile:

```
ACRBottomSheetViewController.mm:192:16
  'keyboardDismissMode' is unavailable in visionOS
** ARCHIVE FAILED **
error: xcodebuild failed with error = 65
```

This reproduced on Xcode 26.3 / XROS 26.2 while adopting 2.12.0 in Teams iOS.

### Change

Wraps the single assignment in `#if !TARGET_OS_VISION`. Two lines, no behaviour change on
iOS; on visionOS the scroll view keeps the default dismiss mode, which is what it already
effectively had since the property is unavailable there.

### Why upstream rather than a consumer patch

Teams iOS has been carrying this guard as a hand-edit to the vendored pod source under
`apps/Packages/Pods/AdaptiveCards/`. That directory is replaced wholesale by `pod update`,
so the guard is silently destroyed on **every** SDK bump and the visionOS archive breaks
again each time. It is also invisible to a normal PR build, because that links the
previously built archive rather than compiling the pod from source, so it only surfaces at
archive time.

Fixing it here removes that recurring failure mode for every consumer and lets us drop the
downstream patch.

### Testing

- Verified the guarded file compiles for `xros` and `xrsimulator` in the Teams iOS
  PrePackageArchive build (archives rebuilt from source, iOS + visionOS both green).
- iOS behaviour unchanged: the assignment is still compiled for all non-visionOS targets.

Targeting a 2.12.1 patch release.
