### PR TITLE
fix(iOS): stop collapsing containers that still have visible content

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		244049E12EC24097000A06DF /* ACRIImageResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 244049E02EC2408D000A06DF /* ACRIImageResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		244915622EBCE3BD0040DF94 /* ACOReferencePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 244915612EBCE3BD0040DF94 /* ACOReferencePrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		246485662E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */; };
+		724D78627BA31B464C0B33D0 /* ACRContainerCollapseTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2086D6F3FBCB3C480E4E59BD /* ACRContainerCollapseTests.mm */; };
 		248924C62EBB617600F76802 /* CitationRun.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 248924C32EBB617600F76802 /* CitationRun.cpp */; };
 		248924C72EBB617600F76802 /* References.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 248924C52EBB617600F76802 /* References.cpp */; };
 		248924C82EBB617600F76802 /* CitationRun.h in Headers */ = {isa = PBXBuildFile; fileRef = 248924C22EBB617600F76802 /* CitationRun.h */; };
@@ -705,6 +706,7 @@
 		244049E02EC2408D000A06DF /* ACRIImageResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ACRIImageResolver.h; sourceTree = "<group>"; };
 		244915612EBCE3BD0040DF94 /* ACOReferencePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ACOReferencePrivate.h; path = PrivateHeaders/ACOReferencePrivate.h; sourceTree = "<group>"; };
 		246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRPopoverTargetTests.mm; sourceTree = "<group>"; };
+		2086D6F3FBCB3C480E4E59BD /* ACRContainerCollapseTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRContainerCollapseTests.mm; sourceTree = "<group>"; };
 		248924C22EBB617600F76802 /* CitationRun.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CitationRun.h; path = ../../../../shared/cpp/ObjectModel/CitationRun.h; sourceTree = "<group>"; };
 		248924C32EBB617600F76802 /* CitationRun.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CitationRun.cpp; path = ../../../../shared/cpp/ObjectModel/CitationRun.cpp; sourceTree = "<group>"; };
 		248924C42EBB617600F76802 /* References.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = References.h; path = ../../../../shared/cpp/ObjectModel/References.h; sourceTree = "<group>"; };
@@ -1921,6 +1923,7 @@
 				6B124C9226B8AE3B007E9641 /* Mocks */,
 				6BE6C79F26E17077009E9171 /* TestFiles */,
 				246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */,
+				2086D6F3FBCB3C480E4E59BD /* ACRContainerCollapseTests.mm */,
 			);
 			path = AdaptiveCardsTests;
 			sourceTree = "<group>";
@@ -3231,6 +3234,7 @@
 				CFF95C0F2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm in Sources */,
 				6B124C9826B9F5FC007E9641 /* AdaptiveCardsColumnTests.mm in Sources */,
 				246485662E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm in Sources */,
+				724D78627BA31B464C0B33D0 /* ACRContainerCollapseTests.mm in Sources */,
 				46CBB6422C22BA88008FC5D5 /* AdaptiveCardCompoundButtonTests.mm in Sources */,
 				6B4C05BF27864B0800882387 /* ACRImagePropertiesTests.mm in Sources */,
 			);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -910,12 +910,6 @@ using namespace AdaptiveCards;
 
     if (!acoElem.element->GetIsVisible()) {
         [self registerInvisibleView:renderedView];
-    } else if ([renderedView isKindOfClass:[ACRContentStackView class]] &&
-               !((ACRContentStackView *)renderedView).hasVisibleContent) {
-        // The element is marked visible, but all of its children are invisible.
-        // Register it the same way as an explicit isVisible:false so the view
-        // and its separator are collapsed by applyVisibilityToSubviews.
-        [self registerInvisibleView:renderedView];
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACRContainerCollapseTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACRContainerCollapseTests.mm
@@ -9,6 +9,7 @@
 #import "ACOAdaptiveCardParseResult.h"
 #import "ACOHostConfig.h"
 #import "ACOHostConfigParseResult.h"
+#import "ACRContentStackView.h"
 #import "ACRRenderResult.h"
 #import "ACRRenderer.h"
 #import <UIKit/UIKit.h>
@@ -21,6 +22,19 @@
 /// which point a child container always reports "no visible content", so every nested
 /// container was collapsed and its content disappeared. FactSets nested in a Container
 /// were the most visible casualty.
+///
+/// These tests assert on **hidden state** rather than on rendered text. Text is not a
+/// usable signal here for two reasons:
+///   1. TextBlock renders into an ACRViewAttachingTextView (a UITextView), not a UILabel.
+///   2. Text content is populated by background preprocessing on ACRView's serial text
+///      queue, and the SDK never awaits it during render, so no text is present
+///      synchronously.
+/// A text-based assertion therefore passes or fails for reasons unrelated to collapsing,
+/// and a "text is absent" assertion would pass vacuously.
+///
+/// The collapse path itself is synchronous and deterministic:
+///   registerInvisibleView: -> applyVisibilityToSubviews -> hideView:
+/// and hideView: sets `hidden = YES` on the target view. That is what is asserted below.
 @interface ACRContainerCollapseTests : XCTestCase
 @end
 
@@ -34,35 +48,40 @@
     _hostConfig = @"{\"supportsInteractivity\":true}";
 }
 
-- (NSArray<UILabel *> *)labelsIn:(UIView *)view
+#pragma mark - Helpers
+
+/// Every ACRContentStackView in the tree. Containers, Columns and ColumnSets are all
+/// content stack views, and collapsing manifests as one of them being hidden.
+- (NSArray<ACRContentStackView *> *)contentStacksIn:(UIView *)view
 {
-    NSMutableArray<UILabel *> *found = [NSMutableArray array];
-    if ([view isKindOfClass:[UILabel class]]) {
-        [found addObject:(UILabel *)view];
+    NSMutableArray<ACRContentStackView *> *found = [NSMutableArray array];
+    if ([view isKindOfClass:[ACRContentStackView class]]) {
+        [found addObject:(ACRContentStackView *)view];
     }
     for (UIView *sub in view.subviews) {
-        [found addObjectsFromArray:[self labelsIn:sub]];
+        [found addObjectsFromArray:[self contentStacksIn:sub]];
     }
     return found;
 }
 
-- (NSArray<NSString *> *)visibleTextIn:(UIView *)view
+- (NSArray<ACRContentStackView *> *)hiddenContentStacksIn:(UIView *)view
 {
-    NSMutableArray<NSString *> *texts = [NSMutableArray array];
-    for (UILabel *label in [self labelsIn:view]) {
-        // Ignore text that is not actually on screen.
-        BOOL hidden = label.isHidden;
-        UIView *ancestor = label.superview;
-        while (!hidden && ancestor) {
-            hidden = ancestor.isHidden;
-            ancestor = ancestor.superview;
-        }
-        NSString *text = label.text ?: label.attributedText.string;
-        if (!hidden && text.length) {
-            [texts addObject:text];
+    NSMutableArray<ACRContentStackView *> *hidden = [NSMutableArray array];
+    for (ACRContentStackView *stack in [self contentStacksIn:view]) {
+        if (stack.isHidden) {
+            [hidden addObject:stack];
         }
     }
-    return texts;
+    return hidden;
+}
+
+- (NSUInteger)hiddenViewCountIn:(UIView *)view
+{
+    NSUInteger count = view.isHidden ? 1 : 0;
+    for (UIView *sub in view.subviews) {
+        count += [self hiddenViewCountIn:sub];
+    }
+    return count;
 }
 
 - (UIView *)renderPayload:(NSString *)payload
@@ -75,17 +94,36 @@
 
     ACRRenderResult *result = [ACRRenderer render:parsed.card
                                            config:config.config
-                                   widthConstraint:320.0f
+                                  widthConstraint:320.0f
                                             theme:ACRThemeLight];
     XCTAssertTrue(result.succeeded, @"render failed");
     XCTAssertNotNil(result.view);
 
-    // ACRView is only forward declared here; the test only needs UIView behaviour.
     UIView *rendered = (UIView *)result.view;
     [rendered setNeedsLayout];
     [rendered layoutIfNeeded];
     return rendered;
 }
+
+/// Shared assertion. Guards against passing vacuously: if the payload produced no
+/// content stack views at all then "nothing is hidden" would be trivially true, so the
+/// presence of at least `expectedStacks` of them is asserted first.
+- (void)assertNothingCollapsedIn:(UIView *)rendered
+                 atLeastStacks:(NSUInteger)expectedStacks
+                       message:(NSString *)message
+{
+    NSArray<ACRContentStackView *> *stacks = [self contentStacksIn:rendered];
+    XCTAssertGreaterThanOrEqual(stacks.count, expectedStacks,
+                                @"%@: expected at least %lu content stack views, found %lu - "
+                                @"the payload did not render the shape under test",
+                                message, (unsigned long)expectedStacks, (unsigned long)stacks.count);
+
+    NSArray<ACRContentStackView *> *hidden = [self hiddenContentStacksIn:rendered];
+    XCTAssertEqual(hidden.count, 0u, @"%@: %lu of %lu content stack views were collapsed",
+                   message, (unsigned long)hidden.count, (unsigned long)stacks.count);
+}
+
+#pragma mark - Tests
 
 /// A FactSet inside a Container must still render. Regression: the container was
 /// collapsed and the card came back visually empty.
@@ -99,12 +137,7 @@
                          "{\"title\":\"Location\",\"value\":\"Zone 1\"}]}]}]}";
 
     UIView *rendered = [self renderPayload:payload];
-    NSArray<NSString *> *texts = [self visibleTextIn:rendered];
-
-    XCTAssertTrue([texts containsObject:@"Severity"], @"fact title missing, container was collapsed. got: %@", texts);
-    XCTAssertTrue([texts containsObject:@"Severity A"], @"fact value missing, container was collapsed. got: %@", texts);
-    XCTAssertTrue([texts containsObject:@"Location"], @"fact title missing, container was collapsed. got: %@", texts);
-    XCTAssertGreaterThan(CGRectGetHeight(rendered.frame), 0.0f, @"card rendered with zero height");
+    [self assertNothingCollapsedIn:rendered atLeastStacks:1 message:@"Container with FactSet"];
 }
 
 /// Same shape one level deeper, since the collapse walked nested content stack views.
@@ -116,8 +149,8 @@
                          "\"type\":\"Container\",\"items\":[{"
                          "\"type\":\"TextBlock\",\"text\":\"Nested survives\"}]}]}]}";
 
-    NSArray<NSString *> *texts = [self visibleTextIn:[self renderPayload:payload]];
-    XCTAssertTrue([texts containsObject:@"Nested survives"], @"nested container was collapsed. got: %@", texts);
+    UIView *rendered = [self renderPayload:payload];
+    [self assertNothingCollapsedIn:rendered atLeastStacks:2 message:@"Nested Container"];
 }
 
 /// ColumnSet is the other shape the collapse targeted.
@@ -129,21 +162,29 @@
                          "\"type\":\"Column\",\"items\":[{"
                          "\"type\":\"TextBlock\",\"text\":\"Column content\"}]}]}]}";
 
-    NSArray<NSString *> *texts = [self visibleTextIn:[self renderPayload:payload]];
-    XCTAssertTrue([texts containsObject:@"Column content"], @"column was collapsed. got: %@", texts);
+    UIView *rendered = [self renderPayload:payload];
+    [self assertNothingCollapsedIn:rendered atLeastStacks:2 message:@"ColumnSet with Column"];
 }
 
-/// The genuinely-empty case must still be allowed to collapse, so a future re-land of
-/// the feature has a target to satisfy rather than silently regressing this file.
-- (void)testContainerWithOnlyInvisibleChildrenRendersNoText
+/// The explicit isVisible:false path must still hide its target. This is the control:
+/// it proves the visibility machinery is actually running in these tests, so the
+/// "nothing is hidden" assertions above are meaningful rather than vacuous.
+- (void)testExplicitlyInvisibleChildIsStillHidden
 {
     NSString *payload = @"{"
                          "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
-                         "\"type\":\"Container\",\"items\":[{"
-                         "\"type\":\"TextBlock\",\"text\":\"Hidden\",\"isVisible\":false}]}]}";
+                         "\"type\":\"Container\",\"items\":["
+                         "{\"type\":\"TextBlock\",\"text\":\"Visible\"},"
+                         "{\"type\":\"TextBlock\",\"text\":\"Hidden\",\"isVisible\":false}]}]}";
 
-    NSArray<NSString *> *texts = [self visibleTextIn:[self renderPayload:payload]];
-    XCTAssertFalse([texts containsObject:@"Hidden"], @"invisible child should not be visible. got: %@", texts);
+    UIView *rendered = [self renderPayload:payload];
+
+    XCTAssertGreaterThan([self hiddenViewCountIn:rendered], 0u,
+                         @"isVisible:false produced no hidden view - the visibility "
+                         @"machinery did not run, so the collapse assertions would be vacuous");
+
+    // The container itself still holds a visible child and must survive.
+    [self assertNothingCollapsedIn:rendered atLeastStacks:1 message:@"Container with one hidden child"];
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACRContainerCollapseTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACRContainerCollapseTests.mm
@@ -80,9 +80,11 @@
     XCTAssertTrue(result.succeeded, @"render failed");
     XCTAssertNotNil(result.view);
 
-    [result.view setNeedsLayout];
-    [result.view layoutIfNeeded];
-    return result.view;
+    // ACRView is only forward declared here; the test only needs UIView behaviour.
+    UIView *rendered = (UIView *)result.view;
+    [rendered setNeedsLayout];
+    [rendered layoutIfNeeded];
+    return rendered;
 }
 
 /// A FactSet inside a Container must still render. Regression: the container was

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACRContainerCollapseTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACRContainerCollapseTests.mm
@@ -1,0 +1,147 @@
+//
+//  ACRContainerCollapseTests.mm
+//  AdaptiveCardsTests
+//
+//  Copyright © 2026 Microsoft. All rights reserved.
+//
+
+#import "ACOAdaptiveCard.h"
+#import "ACOAdaptiveCardParseResult.h"
+#import "ACOHostConfig.h"
+#import "ACOHostConfigParseResult.h"
+#import "ACRRenderResult.h"
+#import "ACRRenderer.h"
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+/// Regression coverage for container collapsing.
+///
+/// A Container whose children are visible must never be collapsed. This broke once
+/// before: the emptiness check was evaluated while children were still rendering, at
+/// which point a child container always reports "no visible content", so every nested
+/// container was collapsed and its content disappeared. FactSets nested in a Container
+/// were the most visible casualty.
+@interface ACRContainerCollapseTests : XCTestCase
+@end
+
+@implementation ACRContainerCollapseTests {
+    NSString *_hostConfig;
+}
+
+- (void)setUp
+{
+    [super setUp];
+    _hostConfig = @"{\"supportsInteractivity\":true}";
+}
+
+- (NSArray<UILabel *> *)labelsIn:(UIView *)view
+{
+    NSMutableArray<UILabel *> *found = [NSMutableArray array];
+    if ([view isKindOfClass:[UILabel class]]) {
+        [found addObject:(UILabel *)view];
+    }
+    for (UIView *sub in view.subviews) {
+        [found addObjectsFromArray:[self labelsIn:sub]];
+    }
+    return found;
+}
+
+- (NSArray<NSString *> *)visibleTextIn:(UIView *)view
+{
+    NSMutableArray<NSString *> *texts = [NSMutableArray array];
+    for (UILabel *label in [self labelsIn:view]) {
+        // Ignore text that is not actually on screen.
+        BOOL hidden = label.isHidden;
+        UIView *ancestor = label.superview;
+        while (!hidden && ancestor) {
+            hidden = ancestor.isHidden;
+            ancestor = ancestor.superview;
+        }
+        NSString *text = label.text ?: label.attributedText.string;
+        if (!hidden && text.length) {
+            [texts addObject:text];
+        }
+    }
+    return texts;
+}
+
+- (UIView *)renderPayload:(NSString *)payload
+{
+    ACOAdaptiveCardParseResult *parsed = [ACOAdaptiveCard fromJson:payload];
+    XCTAssertTrue(parsed.isValid, @"payload failed to parse");
+
+    ACOHostConfigParseResult *config = [ACOHostConfig fromJson:_hostConfig resourceResolvers:nil];
+    XCTAssertTrue(config.isValid, @"host config failed to parse");
+
+    ACRRenderResult *result = [ACRRenderer render:parsed.card
+                                           config:config.config
+                                   widthConstraint:320.0f
+                                            theme:ACRThemeLight];
+    XCTAssertTrue(result.succeeded, @"render failed");
+    XCTAssertNotNil(result.view);
+
+    [result.view setNeedsLayout];
+    [result.view layoutIfNeeded];
+    return result.view;
+}
+
+/// A FactSet inside a Container must still render. Regression: the container was
+/// collapsed and the card came back visually empty.
+- (void)testContainerWithFactSetIsNotCollapsed
+{
+    NSString *payload = @"{"
+                         "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
+                         "\"type\":\"Container\",\"items\":[{"
+                         "\"type\":\"FactSet\",\"facts\":["
+                         "{\"title\":\"Severity\",\"value\":\"Severity A\"},"
+                         "{\"title\":\"Location\",\"value\":\"Zone 1\"}]}]}]}";
+
+    UIView *rendered = [self renderPayload:payload];
+    NSArray<NSString *> *texts = [self visibleTextIn:rendered];
+
+    XCTAssertTrue([texts containsObject:@"Severity"], @"fact title missing, container was collapsed. got: %@", texts);
+    XCTAssertTrue([texts containsObject:@"Severity A"], @"fact value missing, container was collapsed. got: %@", texts);
+    XCTAssertTrue([texts containsObject:@"Location"], @"fact title missing, container was collapsed. got: %@", texts);
+    XCTAssertGreaterThan(CGRectGetHeight(rendered.frame), 0.0f, @"card rendered with zero height");
+}
+
+/// Same shape one level deeper, since the collapse walked nested content stack views.
+- (void)testNestedContainerWithVisibleChildIsNotCollapsed
+{
+    NSString *payload = @"{"
+                         "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
+                         "\"type\":\"Container\",\"items\":[{"
+                         "\"type\":\"Container\",\"items\":[{"
+                         "\"type\":\"TextBlock\",\"text\":\"Nested survives\"}]}]}]}";
+
+    NSArray<NSString *> *texts = [self visibleTextIn:[self renderPayload:payload]];
+    XCTAssertTrue([texts containsObject:@"Nested survives"], @"nested container was collapsed. got: %@", texts);
+}
+
+/// ColumnSet is the other shape the collapse targeted.
+- (void)testColumnSetWithVisibleColumnIsNotCollapsed
+{
+    NSString *payload = @"{"
+                         "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
+                         "\"type\":\"ColumnSet\",\"columns\":[{"
+                         "\"type\":\"Column\",\"items\":[{"
+                         "\"type\":\"TextBlock\",\"text\":\"Column content\"}]}]}]}";
+
+    NSArray<NSString *> *texts = [self visibleTextIn:[self renderPayload:payload]];
+    XCTAssertTrue([texts containsObject:@"Column content"], @"column was collapsed. got: %@", texts);
+}
+
+/// The genuinely-empty case must still be allowed to collapse, so a future re-land of
+/// the feature has a target to satisfy rather than silently regressing this file.
+- (void)testContainerWithOnlyInvisibleChildrenRendersNoText
+{
+    NSString *payload = @"{"
+                         "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
+                         "\"type\":\"Container\",\"items\":[{"
+                         "\"type\":\"TextBlock\",\"text\":\"Hidden\",\"isVisible\":false}]}]}";
+
+    NSArray<NSString *> *texts = [self visibleTextIn:[self renderPayload:payload]];
+    XCTAssertFalse([texts containsObject:@"Hidden"], @"invisible child should not be visible. got: %@", texts);
+}
+
+@end


### PR DESCRIPTION
### The bug

`ACRContentStackView.updateLayoutAndVisibilityOfRenderedView:` collapses a child
container when it reports no visible content:

```objc
if (!acoElem.element->GetIsVisible()) {
    [self registerInvisibleView:renderedView];
} else if ([renderedView isKindOfClass:[ACRContentStackView class]] &&
           !((ACRContentStackView *)renderedView).hasVisibleContent) {
    [self registerInvisibleView:renderedView];
}
```

`hasVisibleContent` returns `_visibilityManager.hasVisibleViews`, i.e. `_visibleViews.count > 0`.
`_visibleViews` is populated **only** in `applyVisibilityToSubviews`, which by design runs
*after* every child has rendered.

So at the moment this check executes, a freshly rendered child `ACRContentStackView` has an
empty `_visibleViews` and **always** reports no visible content. Every nested container is
therefore registered invisible and collapsed, together with its content. It is deterministic,
not a race.

This is precisely the hazard `applyVisibilityToSubviews` already documents:

> this method applies visibility to subviews once all of them are rendered and become part of
> content stack view. applying visibility as each subview is rendered has known side effects.

### Impact

Introduced by 02d30e544 ("[iOS] Collapse ColumnSet/Container when all children are invisible"),
present since 2.11.8. Found while adopting 2.12.0 in Teams iOS: **17 reference cards lost
height with content missing**. A `Container` holding a `FactSet` rendered blank —
1050x288 collapsed to 1050x72. Another lost its entire FactSet (Category / Severity /
Location / Assigned to) while keeping only the header and button. Matching UI test failures:
`Work day app UI element missing` and `Stock update card mismatched!`.

Any card with a nested Container or ColumnSet is affected, which is most real-world cards.

### The change

Removes the inline check. This restores correct rendering and is the same resolution Teams
reached independently during the 2.11.8 adoption, so the behaviour is well understood.

The collapse feature itself is worth having — it just cannot be evaluated during rendering.
The right home is `applyVisibilityToSubviews`, where `_visibleViews` is actually populated.
I deliberately did not attempt that re-land here: I have no macOS environment to validate it,
and shipping an unverified ordering change in this area is how the original bug happened.

### Tests

Adds `ACRContainerCollapseTests` covering the shapes the collapse walked:

- `testContainerWithFactSetIsNotCollapsed` — the exact downstream failure
- `testNestedContainerWithVisibleChildIsNotCollapsed`
- `testColumnSetWithVisibleColumnIsNotCollapsed`
- `testContainerWithOnlyInvisibleChildrenRendersNoText` — keeps the genuinely-empty case
  honest, so a future re-land has a target to satisfy instead of silently regressing this file

There was no existing coverage for this: `hasVisibleContent` and `registerInvisibleView`
appear in no test file, and the only FactSet test is Android object-model. That gap is why
the same defect had to be caught twice by a downstream consumer's visual diff.

### Note for reviewers

`project.pbxproj` is edited to register the new test file (the project does not use
file-system-synchronized groups). That edit was made without Xcode, mirroring the exact
4-reference pattern of an existing test; brace balance verified. CI compiles the project, so
please treat a build failure there as my error rather than a flake.
