### PR TITLE
fix(ios): announce CompoundButton as a single button to VoiceOver

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
@@ -109,7 +109,21 @@
     std::shared_ptr<BaseActionElement> selectAction = compoundButton->GetSelectAction();
     ACOBaseActionElement *acoSelectAction = [ACOBaseActionElement getACOActionElementFromAdaptiveElement:selectAction];
     addSelectActionToView(acoConfig, acoSelectAction, rootView, compoundButtonView, viewGroup);
-    compoundButtonView.accessibilityLabel = @(compoundButton->getTitle().c_str());
+
+    // Expose the compound button as a single accessible button. Previously only the
+    // title was set as the label and no button trait was applied, so VoiceOver read
+    // the inner labels individually and never announced the control role. Combine
+    // the title, badge and description into one label and mark the view as a button.
+    compoundButtonView.isAccessibilityElement = YES;
+    NSMutableArray<NSString *> *compoundButtonLabelParts = [NSMutableArray array];
+    NSString *compoundButtonTitle = @(compoundButton->getTitle().c_str());
+    NSString *compoundButtonBadge = @(compoundButton->getBadge().c_str());
+    NSString *compoundButtonDescription = @(compoundButton->getDescription().c_str());
+    if (compoundButtonTitle.length) { [compoundButtonLabelParts addObject:compoundButtonTitle]; }
+    if (compoundButtonBadge.length) { [compoundButtonLabelParts addObject:compoundButtonBadge]; }
+    if (compoundButtonDescription.length) { [compoundButtonLabelParts addObject:compoundButtonDescription]; }
+    compoundButtonView.accessibilityLabel = [compoundButtonLabelParts componentsJoinedByString:@", "];
+    compoundButtonView.accessibilityTraits |= UIAccessibilityTraitButton;
     NSString *areaName = stringForCString(elem->GetAreaGridName());
     [viewGroup addArrangedSubview:compoundButtonView withAreaName:areaName];
     return compoundButtonView;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
@@ -115,7 +115,8 @@
     // the inner labels individually and never announced the control role. Combine
     // the title, badge and description into one label and mark the view as a button.
     compoundButtonView.isAccessibilityElement = YES;
-    NSMutableArray<NSString *> *compoundButtonLabelParts = [NSMutableArray array];
+    // At most three parts: title, badge, description.
+    NSMutableArray<NSString *> *compoundButtonLabelParts = [NSMutableArray arrayWithCapacity:3];
     NSString *compoundButtonTitle = @(compoundButton->getTitle().c_str());
     NSString *compoundButtonBadge = @(compoundButton->getBadge().c_str());
     NSString *compoundButtonDescription = @(compoundButton->getDescription().c_str());


### PR DESCRIPTION
## Summary

A `CompoundButton` is announced to VoiceOver as several unrelated text fragments with **no control role**. A screen-reader user hears the title, badge and description as separate static items and gets no indication that the element is actuatable.

## Root cause

`ACRCompoundButtonRenderer` sets only the title as the label and applies no accessibility trait:

```objc
compoundButtonView.accessibilityLabel = @(compoundButton->getTitle().c_str());
```

The wrapping view is never made a single accessibility element, so VoiceOver descends into it and reads the inner title/badge/description labels individually. Because no trait is applied, the button role is never announced either.

## Change

`ACRCompoundButtonRenderer.mm` — make the compound button one accessibility element, build its label from title + badge + description, and OR in the button trait:

```objc
compoundButtonView.isAccessibilityElement = YES;
// ... title / badge / description joined with ", "
compoundButtonView.accessibilityLabel = [compoundButtonLabelParts componentsJoinedByString:@", "];
compoundButtonView.accessibilityTraits |= UIAccessibilityTraitButton;
```

The trait is OR'd rather than assigned so traits already applied by `setAccessibilityTrait` (for example `UIAccessibilityTraitNotEnabled` for a disabled action) are preserved.

## Accessibility evidence (before → after)

VoiceOver element scan of `samples/v1.5/Scenarios/CompoundButtonSample.json`, captured through the real UIAccessibility API (`XCUIElement`) on an iOS simulator, measured against an **otherwise identical control build** so the delta is attributable to this change alone:

| | a11y tree |
|---|---|
| **before** | 12 elements — `{ text: 12 }` |
| **after** | 5 elements — `{ button: 5 }` |

Twelve loose text fragments become five buttons, one per compound button, each announced with its full content and the correct role. Reproduced across two independent control/fix run pairs.

Annotated overlay:

![CompoundButton accessibility overlay](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5532275_compoundbutton.png)

Raw per-element dump (label / value / role / bounds / what VoiceOver reads):
https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5532275_compoundbutton_elements.json

## Scope

One file. No behaviour change for cards without a `CompoundButton`.

Work item: **AB#5532275** (A11yMAS, A11ySev2)
