### PR TITLE
fix(ios): apply the LTR semantic content attribute (configRtl tested RTL twice)

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -95,7 +95,7 @@ void configRtl(UIView *view, ACORenderContext *context)
         return;
     } else if (rtl == ACRRtlRTL) {
         view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    } else if (rtl == ACRRtlRTL) {
+    } else if (rtl == ACRRtlLTR) {
         view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     }
 }


### PR DESCRIPTION
## Summary

A card that explicitly requests left-to-right layout (`"rtl": false`) never has LTR semantics forced. `UISemanticContentAttributeForceLeftToRight` is dead code today, so such a card inherits whatever direction the surrounding context provides instead of overriding it.

## Root cause

`configRtl` in `UtiliOS.mm` tests the same condition in two consecutive branches:

```objc
} else if (rtl == ACRRtlRTL) {
    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
} else if (rtl == ACRRtlRTL) {
    view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
}
```

The second branch is unreachable — anything matching `ACRRtlRTL` is consumed by the first. The `ACRRtlLTR` case therefore falls through and no semantic content attribute is set.

Still present on `main` as of this PR.

## Change

Test `ACRRtlLTR` in the second branch, which is what it was evidently meant to do.

One character. `ACRRtlNone` and `ACRRtlRTL` behave exactly as before; the only newly reachable path is the one always intended for `ACRRtlLTR`.

## Accessibility evidence (before → after)

**None, and I would rather state that than overstate it.**

The defect is a self-evident unreachable branch, verified present on `main` by reading the current source rather than inferred. But the `AdaptiveCard.Rtl.False.json` scenario could not be captured in a matched control run, so there is no before/after element scan to attach here. That is a limitation of our scenario capture, not evidence that the change is inert.

Submitted on the strength of the code reading. Happy to hold until a matched scan is available if reviewers would prefer that.

## Scope

One file, one line.

Work item: **AB#5536877** (A11yMAS, A11ySev2)
Supersedes #644, which carried the same fix on a fork branch and therefore never ran CI. That PR should be closed if this one is accepted.
