### PR TITLE
fix(ios): announce rating stars as buttons and repair the read-only rating label

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerUITests/ADCIOSVisualizerUITests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerUITests/ADCIOSVisualizerUITests.mm
@@ -599,7 +599,10 @@
 
     // Adjust this to select a rating (e.g., tap the 4th star for rating=4)
     // Tap the 4th star for rating=4
-    XCUIElement *fourthStar = [testApp.images elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Rate 4 Star"]];
+    // The star now carries UIAccessibilityTraitButton, so it resolves as a button rather
+    // than an image. That role change is the point of the fix - VoiceOver previously
+    // announced "Rate 4 Star, image" with no indication the control was actuatable.
+    XCUIElement *fourthStar = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Rate 4 Star"]];
     XCTAssertTrue(fourthStar.exists && fourthStar.isHittable, @"The 4th star should exist and be hittable");
     [fourthStar tap];
 
@@ -656,7 +659,10 @@
 
     // Adjust this to select a rating (e.g., tap the 4th star for rating=4)
     // Tap the 4th star for rating=4
-    XCUIElement *fourthStar = [testApp.images elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Rate 4 Star"]];
+    // The star now carries UIAccessibilityTraitButton, so it resolves as a button rather
+    // than an image. That role change is the point of the fix - VoiceOver previously
+    // announced "Rate 4 Star, image" with no indication the control was actuatable.
+    XCUIElement *fourthStar = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Rate 4 Star"]];
     XCTAssertTrue(fourthStar.exists && fourthStar.isHittable, @"The 4th star should exist and be hittable");
     [fourthStar tap];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingView.mm
@@ -94,6 +94,9 @@
         starImageView.userInteractionEnabled = YES;
         starImageView.isAccessibilityElement = YES;
         starImageView.accessibilityLabel = [NSString stringWithFormat:@"Rate %d Star", (int)i+1];
+        // Each star is tappable, so announce it as a button. Without a trait VoiceOver
+        // reads "Rate 3 Star, image" and gives no indication the control is actuatable.
+        starImageView.accessibilityTraits |= UIAccessibilityTraitButton;
         UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleStarTap:)];
         [starImageView addGestureRecognizer:tapGesture];
         [_accessibleChildren addObject:starImageView];
@@ -129,13 +132,16 @@
     _ratingLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _ratingLabel.translatesAutoresizingMaskIntoConstraints = NO;
     _ratingLabel.attributedText = [self atrributedStringForLabel];
+    // These branches were inverted: a rating WITH a count announced "Rating 3.2," -
+    // dropping the count and leaving a dangling comma that VoiceOver pauses on - while a
+    // rating WITHOUT a count announced the meaningless "Count 0".
     if (_count > 0)
     {
-        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f,", (float)_value];
+        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f, Count %d", (float)_value, (int)_count];
     }
     else
     {
-        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f, Count %d", (float)_value, (int)_count];
+        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f", (float)_value];
     }
     
     [self addSubview:_ratingLabel];


### PR DESCRIPTION
## Summary

Two accessibility defects in `ACRRatingView`:

1. **Interactive rating stars are announced as images.** They are accessibility elements with good labels (`"Rate 3 Star"`) but carry no trait, so VoiceOver reads *"Rate 3 Star, image"* and gives no indication the control can be activated.
2. **The read-only rating label drops its count.** A rating that has a count announces `"Rating 3.2,"` — count omitted, dangling comma — while a rating with no count announces the meaningless `"Count 0"`.

## Root cause

**Stars** — `setupViewForInput` sets `isAccessibilityElement` and a label but no trait:

```objc
starImageView.isAccessibilityElement = YES;
starImageView.accessibilityLabel = [NSString stringWithFormat:@"Rate %d Star", (int)i+1];
UITapGestureRecognizer *tapGesture = ...
```

**Label** — the branches in `setupReadOnlyView` are inverted:

```objc
if (_count > 0)  { @"Rating %.1f,"          }   // has a count -> count dropped
else             { @"Rating %.1f, Count %d" }   // no count -> announces "Count 0"
```

The trailing comma in the first format is the giveaway: it was written to be followed by the count, which that branch never appends.

## Change

`ACRRatingView.mm` — OR in `UIAccessibilityTraitButton` for each tappable star, and swap the count branches so a rating with a count announces it and one without simply omits it.

## Accessibility evidence (before → after)

VoiceOver element scan of `samples/v1.5/Scenarios/RatingInput.json` through the real UIAccessibility API (`XCUIElement`), against an **otherwise identical control build** — same harness, only this file differs:

| | a11y tree |
|---|---|
| **before** | 17 elements — `{ image: 10, text: 4, textView: 2, button: 1 }` |
| **after** | 17 elements — `{ button: 11, text: 4, textView: 2 }` |

Element level:

| | before | after |
|---|---|---|
| Rate 1–5 Star (×10) | `role=image` | `role=button` |
| read-only rating 1 | `"Rating 3.2,"` | `"Rating 3.2, Count 10"` |
| read-only rating 2 | `"Rating 3.2,"` | `"Rating 3.2, Count 150"` |
| read-only rating 3 | `"Rating 3.2,"` | `"Rating 3.2, Count 1500"` |

The three read-only ratings on this card have **different** counts (10, 150, 1500) and every one was announcing identically. Element count is unchanged at 17, so nothing was added or removed — these are role and label corrections only.

### Annotated overlay

![Rating input accessibility overlay](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5535831_rating_input.png)

Raw per-element dump:
https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5535831_rating_input_elements.json

## Scope

One file. No layout or behaviour change; tap handling is untouched.

Work item: **AB#5535831** (A11yMAS, A11ySev2)
