### PR TITLE
fix(ios): give ChoiceSet cells a real accessible name

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -168,16 +168,30 @@ const CGFloat minimumRowHeight = 44.0;
     _accessibilityString = accessibilityLabel ? accessibilityLabel : @"";
     cell.accessibilityTraits = cell.accessibilityTraits;
     
-    // If required field voice over should call it out as required.
-    if (isRequired)
-    {
-        cell.accessibilityLabel = [NSString stringWithFormat:@"%@ %@, %@, %@", _accessibilityString, @"(Required)", cell.textLabel.text, _isMultiChoicesAllowed ? @"check box" : @"radio button"];
-        cell.accessibilityLabel = [cell.accessibilityLabel stringByReplacingOccurrencesOfString:@"*" withString:@""];
+    // Build the label from the parts that actually have content. The previous format
+    // strings always emitted their separators, so a ChoiceSet with no accessible name
+    // produced ", Red, check box" - a leading comma where the name should be, which
+    // VoiceOver reads as a pause and leaves the control effectively unnamed.
+    NSMutableArray<NSString *> *components = [NSMutableArray array];
+
+    NSString *name = [_accessibilityString stringByTrimmingCharactersInSet:
+                      [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (name.length > 0) {
+        if (isRequired) {
+            name = [NSString stringWithFormat:@"%@ %@", name, NSLocalizedString(@"(Required)", nil)];
+        }
+        [components addObject:name];
+    } else if (isRequired) {
+        [components addObject:NSLocalizedString(@"(Required)", nil)];
     }
-    else
-    {
-        cell.accessibilityLabel = [NSString stringWithFormat:@"%@, %@, %@", _accessibilityString, cell.textLabel.text, _isMultiChoicesAllowed ? @"check box" : @"radio button"];
+
+    if (cell.textLabel.text.length > 0) {
+        [components addObject:cell.textLabel.text];
     }
+    [components addObject:_isMultiChoicesAllowed ? @"check box" : @"radio button"];
+
+    cell.accessibilityLabel = [[components componentsJoinedByString:@", "]
+                               stringByReplacingOccurrencesOfString:@"*" withString:@""];
     
     cell.accessibilityHint = NSLocalizedString(@"double tap to select", nil);
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -172,7 +172,9 @@ const CGFloat minimumRowHeight = 44.0;
     // strings always emitted their separators, so a ChoiceSet with no accessible name
     // produced ", Red, check box" - a leading comma where the name should be, which
     // VoiceOver reads as a pause and leaves the control effectively unnamed.
-    NSMutableArray<NSString *> *components = [NSMutableArray array];
+    // At most three components: the name (optionally with the required suffix), the
+    // choice text, and the control role.
+    NSMutableArray<NSString *> *components = [NSMutableArray arrayWithCapacity:3];
 
     NSString *name = [_accessibilityString stringByTrimmingCharactersInSet:
                       [NSCharacterSet whitespaceAndNewlineCharacterSet]];


### PR DESCRIPTION
## Summary

VoiceOver announces ChoiceSet cells as **`", Red, check box"`** — a leading comma sitting
where the control's name should be.

## Root cause

`configureCellForAccsessibility` builds the label with a format string that always emits
its separators:

```objc
cell.accessibilityLabel = [NSString stringWithFormat:@"%@, %@, %@",
                           _accessibilityString, cell.textLabel.text, ...];
```

When the table has no accessible name, `_accessibilityString` is `@""` — but the
separator is still written, so the name slot renders as an empty leading comma. VoiceOver
reads that as a pause and the control is effectively unnamed.

## Change

`ACRChoiceSetViewDataSource.mm` — build the label from the components that actually have
content and join them, so an absent name contributes no separator. The `(Required)`
suffix and the `*` stripping behave as before.

## Accessibility evidence (before → after)

Captured with an XCUITest harness that dumps the real `UIAccessibility` tree, comparing
against a matched control run that differs by this file alone.

Card: `samples/v1.1/Tests/ColumnSet.Input.ChoiceSet.VerticalStretch.json`

| | cells | cells with an empty name |
|---|---|---|
| before | 9 | **9** |
| after | 9 | **0** |

```
before:  [cell] ', Red, check box'      after:  [cell] 'Red, check box'
         [cell] ', Green, check box'            [cell] 'Green, check box'
         [cell] ', Blue, radio button'          [cell] 'Blue, radio button'
```

### Scope note

None of the four `Input.ChoiceSet` elements in that sample define a `label`, so there is
no name for the control to announce on this card. This change removes a malformed
separator that made the control read as unnamed; it does not invent a name the card never
supplied. A card that does set `label` should be used to verify the full announcement.
