### PR TITLE
fix(ios): mark ACRIBaseCardElementRenderer as main-actor isolated

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIBaseCardElementRenderer.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIBaseCardElementRenderer.h
@@ -19,19 +19,19 @@
            rootView:(ACRView *)rootView
              inputs:(NSMutableArray *)inputs
     baseCardElement:(ACOBaseCardElement *)acoElem
-         hostConfig:(ACOHostConfig *)acoConfig;
+         hostConfig:(ACOHostConfig *)acoConfig NS_SWIFT_UI_ACTOR;
 @optional
 /// override this method for custom styling
 /// not all renderers supports it
 - (void)configure:(UIView *)view
            rootView:(ACRView *)rootView
     baseCardElement:(ACOBaseCardElement *)acoElem
-         hostConfig:(ACOHostConfig *)acoConfig;
+         hostConfig:(ACOHostConfig *)acoConfig NS_SWIFT_UI_ACTOR;
 
 - (void)configureVC:(UIViewController *)view
            rootView:(ACRView *)rootView
     baseCardElement:(ACOBaseCardElement *)acoElem
-         hostConfig:(ACOHostConfig *)acoConfig;
+         hostConfig:(ACOHostConfig *)acoConfig NS_SWIFT_UI_ACTOR;
 @end
 
 @protocol ACRIKVONotificationHandler


### PR DESCRIPTION
## Summary

`ACRIBaseCardElementRenderer.render` is missing `NS_SWIFT_UI_ACTOR`, which makes it
unusable from a Swift subclass under Swift 6 strict concurrency.

## Repro

1. Integrate AdaptiveCards into a project using Swift 6 strict concurrency checking
2. Create a Swift subclass of `ACRBaseCardElementRenderer`
3. Override `render(_:rootView:inputs:baseCardElement:hostConfig:)`
4. From the override, call a `@MainActor`-isolated API while synchronously constructing
   the returned UIKit view

```swift
final class CustomRenderer: ACRBaseCardElementRenderer {
    override func render(
        _ viewGroup: UIView & ACRIContentHoldingView,
        rootView: ACRView,
        inputs: NSMutableArray,
        baseCardElement element: ACOBaseCardElement,
        hostConfig: ACOHostConfig
    ) -> UIView {
        makeView()          // error under Swift 6
    }

    @MainActor
    private func makeView() -> UIView { UIView() }
}
```

## Root cause

The Objective-C declaration has no actor annotation, so Swift imports the override as
`nonisolated`. Swift 6 then rejects calls to main-actor-isolated UI APIs from it.

The method is synchronous and must immediately return a `UIView`, so it cannot use
`await MainActor.run`. Annotating only the Swift override conflicts with the nonisolated
superclass declaration. Consumers are left with:

```swift
MainActor.assumeIsolated {
    // Construct and configure the view.
}
```

which asserts the contract at runtime instead of expressing it to the compiler.

## Change

`ACRIBaseCardElementRenderer.h` — annotate `render:`, `configure:` and `configureVC:`
with `NS_SWIFT_UI_ACTOR`. All three synchronously create or mutate UIKit views.

This matches the existing precedent in the sibling protocol: `ACRIBaseActionElementRenderer.h`
already annotates both `renderButton:` and `renderButtons:` the same way.

## Testing

Compile-time isolation contract, so there is no runtime behaviour to capture — verified by
the iOS build and unit test legs. The meaningful test is a Swift 6 consumer overriding the
renderer without `MainActor.assumeIsolated`.
