### PR TITLE
fix(ios): restore VoiceOver focus after the overflow menu is cancelled

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		244049E12EC24097000A06DF /* ACRIImageResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 244049E02EC2408D000A06DF /* ACRIImageResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		244915622EBCE3BD0040DF94 /* ACOReferencePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 244915612EBCE3BD0040DF94 /* ACOReferencePrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		246485662E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */; };
+		2AC0F7A22F01000B0085F3BD /* ACROverflowTargetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */; };
 		248924C62EBB617600F76802 /* CitationRun.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 248924C32EBB617600F76802 /* CitationRun.cpp */; };
 		248924C72EBB617600F76802 /* References.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 248924C52EBB617600F76802 /* References.cpp */; };
 		248924C82EBB617600F76802 /* CitationRun.h in Headers */ = {isa = PBXBuildFile; fileRef = 248924C22EBB617600F76802 /* CitationRun.h */; };
@@ -705,6 +706,7 @@
 		244049E02EC2408D000A06DF /* ACRIImageResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ACRIImageResolver.h; sourceTree = "<group>"; };
 		244915612EBCE3BD0040DF94 /* ACOReferencePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ACOReferencePrivate.h; path = PrivateHeaders/ACOReferencePrivate.h; sourceTree = "<group>"; };
 		246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRPopoverTargetTests.mm; sourceTree = "<group>"; };
+		2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACROverflowTargetTests.mm; sourceTree = "<group>"; };
 		248924C22EBB617600F76802 /* CitationRun.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CitationRun.h; path = ../../../../shared/cpp/ObjectModel/CitationRun.h; sourceTree = "<group>"; };
 		248924C32EBB617600F76802 /* CitationRun.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CitationRun.cpp; path = ../../../../shared/cpp/ObjectModel/CitationRun.cpp; sourceTree = "<group>"; };
 		248924C42EBB617600F76802 /* References.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = References.h; path = ../../../../shared/cpp/ObjectModel/References.h; sourceTree = "<group>"; };
@@ -1921,6 +1923,7 @@
 				6B124C9226B8AE3B007E9641 /* Mocks */,
 				6BE6C79F26E17077009E9171 /* TestFiles */,
 				246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */,
+				2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */,
 			);
 			path = AdaptiveCardsTests;
 			sourceTree = "<group>";
@@ -3231,6 +3234,7 @@
 				CFF95C0F2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm in Sources */,
 				6B124C9826B9F5FC007E9641 /* AdaptiveCardsColumnTests.mm in Sources */,
 				246485662E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm in Sources */,
+				2AC0F7A22F01000B0085F3BD /* ACROverflowTargetTests.mm in Sources */,
 				46CBB6422C22BA88008FC5D5 /* AdaptiveCardCompoundButtonTests.mm in Sources */,
 				6B4C05BF27864B0800882387 /* ACRImagePropertiesTests.mm in Sources */,
 			);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
@@ -46,6 +46,8 @@
         ACRTargetBuilderDirector *director = [rootView getActionsTargetBuilderDirector];
         ACRRenderingStatus status = buildTargetForButton(director, acoElem, button, &target);
         if (ACRRenderingStatus::ACROk == status) {
+            // So the menu can hand VoiceOver focus back to this button on dismissal.
+            target.accessibilityFocusAnchor = button;
             [superview addTarget:target];
             // to support Action.ShowCard in menu item action, this line is required
             [target setInputs:inputs superview:superview];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.h
@@ -31,4 +31,9 @@
 
 @property (readonly) NSArray<ACROverflowMenuItem *> *menuItems;
 
+/// The control that opened the overflow menu. VoiceOver focus is returned here when the
+/// menu is dismissed, so the user lands back where they were instead of at the top of
+/// the screen.
+@property (nonatomic, weak) UIView *accessibilityFocusAnchor;
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.h
@@ -36,4 +36,8 @@
 /// the screen.
 @property (nonatomic, weak) UIView *accessibilityFocusAnchor;
 
+/// Hands VoiceOver focus back to ``accessibilityFocusAnchor``. Called when the menu is
+/// dismissed. A no-op when no anchor is set or the anchor has already gone away.
+- (void)restoreAccessibilityFocusToAnchor;
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
@@ -242,9 +242,20 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
         }
     }
 
+    // Dismissing the sheet has to say where focus goes. With a nil handler nothing posts
+    // an accessibility notification, so VoiceOver falls back to the platform default and
+    // the user loses their place instead of returning to the control they opened the menu
+    // from. ACRShowCardTarget already handles the equivalent case this way.
+    __weak __typeof(self) weakSelf = self;
     [_alert addAction:[UIAlertAction actionWithTitle:@"Cancel"
                                                style:UIAlertActionStyleCancel
-                                             handler:nil]];
+                                             handler:^(UIAlertAction *action) {
+                                                 __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                                 UIView *anchor = strongSelf.accessibilityFocusAnchor;
+                                                 if (anchor) {
+                                                     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, anchor);
+                                                 }
+                                             }]];
 }
 
 - (void)setInputs:(NSMutableArray *)inputs

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
@@ -249,13 +249,17 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
     __weak __typeof(self) weakSelf = self;
     [_alert addAction:[UIAlertAction actionWithTitle:@"Cancel"
                                                style:UIAlertActionStyleCancel
-                                             handler:^(UIAlertAction *action) {
-                                                 __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                                 UIView *anchor = strongSelf.accessibilityFocusAnchor;
-                                                 if (anchor) {
-                                                     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, anchor);
-                                                 }
+                                             handler:^(__unused UIAlertAction *action) {
+                                                 [weakSelf restoreAccessibilityFocusToAnchor];
                                              }]];
+}
+
+- (void)restoreAccessibilityFocusToAnchor
+{
+    UIView *anchor = self.accessibilityFocusAnchor;
+    if (anchor) {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, anchor);
+    }
 }
 
 - (void)setInputs:(NSMutableArray *)inputs

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOActionOverflowPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOActionOverflowPrivate.h
@@ -18,6 +18,11 @@
 
 using namespace AdaptiveCards;
 
+/// Used by reference in the initializer below. Declared here so this header compiles on
+/// its own: it previously relied on whatever imported it having already pulled the type
+/// in, which held for ACRActionSetRenderer.mm only because its own header does so first.
+@class ACOAdaptiveCard;
+
 @interface ACOActionOverflow : ACOBaseActionElement
 
 - (instancetype)initWithBaseActionElements:(const std::vector<std::shared_ptr<BaseActionElement>> &)elements

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOActionOverflowPrivate.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/PrivateHeaders/ACOActionOverflowPrivate.h
@@ -18,11 +18,6 @@
 
 using namespace AdaptiveCards;
 
-/// Used by reference in the initializer below. Declared here so this header compiles on
-/// its own: it previously relied on whatever imported it having already pulled the type
-/// in, which held for ACRActionSetRenderer.mm only because its own header does so first.
-@class ACOAdaptiveCard;
-
 @interface ACOActionOverflow : ACOBaseActionElement
 
 - (instancetype)initWithBaseActionElements:(const std::vector<std::shared_ptr<BaseActionElement>> &)elements

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACROverflowTargetTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACROverflowTargetTests.mm
@@ -1,0 +1,104 @@
+//
+//  ACROverflowTargetTests.mm
+//  AdaptiveCardsTests
+//
+//  Copyright © 2026 Microsoft. All rights reserved.
+//
+
+#import "ACOActionOverflow.h"
+#import "ACROverflowTarget.h"
+#import "ACRView.h"
+#import <XCTest/XCTest.h>
+
+@interface ACROverflowTargetTests : XCTestCase
+@end
+
+@implementation ACROverflowTargetTests
+
+- (ACROverflowTarget *)makeTarget
+{
+    ACOActionOverflow *actionElement = [[ACOActionOverflow alloc] init];
+    actionElement.menuActions = @[];
+    ACRView *rootView = [[ACRView alloc] initWithFrame:CGRectZero];
+    return [[ACROverflowTarget alloc] initWithActionElement:actionElement rootView:rootView];
+}
+
+- (UIAlertAction *)cancelActionOf:(ACROverflowTarget *)target
+{
+    UIAlertController *alert = [target valueForKey:@"_alert"];
+    for (UIAlertAction *action in alert.actions) {
+        if (action.style == UIAlertActionStyleCancel) {
+            return action;
+        }
+    }
+    return nil;
+}
+
+/// The sheet must offer a way out; that action is what hands focus back.
+- (void)testOverflowSheetHasACancelAction
+{
+    UIAlertAction *cancel = [self cancelActionOf:[self makeTarget]];
+    XCTAssertNotNil(cancel, @"the overflow sheet should offer a cancel action");
+    XCTAssertEqual(cancel.style, UIAlertActionStyleCancel);
+}
+
+/// The anchor is the control the user opened the menu from.
+- (void)testFocusAnchorRoundTrips
+{
+    ACROverflowTarget *target = [self makeTarget];
+    UIView *button = [[UIView alloc] initWithFrame:CGRectZero];
+    target.accessibilityFocusAnchor = button;
+    XCTAssertEqual(target.accessibilityFocusAnchor, button);
+}
+
+/// The anchor is weak on purpose: the menu must never keep the button alive.
+- (void)testFocusAnchorDoesNotRetainTheButton
+{
+    ACROverflowTarget *target = [self makeTarget];
+    @autoreleasepool {
+        UIView *button = [[UIView alloc] initWithFrame:CGRectZero];
+        target.accessibilityFocusAnchor = button;
+        XCTAssertNotNil(target.accessibilityFocusAnchor);
+    }
+    XCTAssertNil(target.accessibilityFocusAnchor,
+                 @"the anchor must not retain the button that opened the menu");
+}
+
+/// The defect this guards: dismissing the sheet used to do nothing at all, so VoiceOver
+/// fell back to the top of the card instead of the control the user came from. Driving
+/// the restoration with a live anchor must complete cleanly.
+///
+/// Note this asserts the restoration path runs and is safe, not that VoiceOver received
+/// the notification — UIAccessibility notifications are delivered to the accessibility
+/// server and are not observable from a unit test with VoiceOver off.
+- (void)testRestoringFocusWithAnAnchorIsSafe
+{
+    ACROverflowTarget *target = [self makeTarget];
+    UIView *button = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+    target.accessibilityFocusAnchor = button;
+    XCTAssertNoThrow([target restoreAccessibilityFocusToAnchor]);
+}
+
+/// If the anchor has gone away, restoration must be a no-op rather than posting an
+/// unanchored notification or touching a released view.
+- (void)testRestoringFocusWithoutAnAnchorIsANoOp
+{
+    ACROverflowTarget *target = [self makeTarget];
+    XCTAssertNil(target.accessibilityFocusAnchor);
+    XCTAssertNoThrow([target restoreAccessibilityFocusToAnchor]);
+}
+
+/// The cancel handler captures self weakly; the target must still deallocate.
+- (void)testTargetDeallocates
+{
+    __weak ACROverflowTarget *weakTarget;
+    @autoreleasepool {
+        ACROverflowTarget *target = [self makeTarget];
+        target.accessibilityFocusAnchor = [[UIView alloc] initWithFrame:CGRectZero];
+        weakTarget = target;
+        target = nil;
+    }
+    XCTAssertNil(weakTarget, @"ACROverflowTarget should deallocate (no retain cycle)");
+}
+
+@end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACROverflowTargetTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACROverflowTargetTests.mm
@@ -5,7 +5,9 @@
 //  Copyright © 2026 Microsoft. All rights reserved.
 //
 
-#import "ACOActionOverflow.h"
+#import "ACOActionOverflowPrivate.h"
+#import "ACOAdaptiveCard.h"
+#import "ACOAdaptiveCardParseResult.h"
 #import "ACROverflowTarget.h"
 #import "ACRView.h"
 #import <XCTest/XCTest.h>
@@ -15,17 +17,30 @@
 
 @implementation ACROverflowTargetTests
 
+/// ACOActionOverflow works out whether it sits at the card's root by walking that card's
+/// actions, so it needs a real card. Built through the designated initializer, which is
+/// also what ACRActionSetRenderer uses, so these tests exercise the production path.
+- (ACOActionOverflow *)makeOverflowElement
+{
+    NSString *payload = @"{\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[]}";
+    ACOAdaptiveCardParseResult *parseResult = [ACOAdaptiveCard fromJson:payload];
+    XCTAssertTrue(parseResult.isValid, @"the fixture card should parse");
+
+    std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>> noMenuActions;
+    return [[ACOActionOverflow alloc] initWithBaseActionElements:noMenuActions
+                                                          atCard:parseResult.card];
+}
+
 - (ACROverflowTarget *)makeTarget
 {
-    ACOActionOverflow *actionElement = [[ACOActionOverflow alloc] init];
-    actionElement.menuActions = @[];
     ACRView *rootView = [[ACRView alloc] initWithFrame:CGRectZero];
-    return [[ACROverflowTarget alloc] initWithActionElement:actionElement rootView:rootView];
+    return [[ACROverflowTarget alloc] initWithActionElement:[self makeOverflowElement]
+                                                   rootView:rootView];
 }
 
 - (UIAlertAction *)cancelActionOf:(ACROverflowTarget *)target
 {
-    UIAlertController *alert = [target valueForKey:@"_alert"];
+    UIAlertController *alert = [target valueForKey:@"alert"];
     for (UIAlertAction *action in alert.actions) {
         if (action.style == UIAlertActionStyleCancel) {
             return action;
@@ -92,13 +107,17 @@
 - (void)testTargetDeallocates
 {
     __weak ACROverflowTarget *weakTarget;
+    // Held strongly out here on purpose: assigning a freshly created view straight to the
+    // weak anchor would release it on the spot and the assertion would prove nothing.
+    UIView *button = [[UIView alloc] initWithFrame:CGRectZero];
     @autoreleasepool {
         ACROverflowTarget *target = [self makeTarget];
-        target.accessibilityFocusAnchor = [[UIView alloc] initWithFrame:CGRectZero];
+        target.accessibilityFocusAnchor = button;
         weakTarget = target;
         target = nil;
     }
     XCTAssertNil(weakTarget, @"ACROverflowTarget should deallocate (no retain cycle)");
+    XCTAssertNotNil(button, @"the anchor outlives the target");
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACROverflowTargetTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACROverflowTargetTests.mm
@@ -5,12 +5,22 @@
 //  Copyright © 2026 Microsoft. All rights reserved.
 //
 
-#import "ACOActionOverflowPrivate.h"
 #import "ACOAdaptiveCard.h"
 #import "ACOAdaptiveCardParseResult.h"
 #import "ACROverflowTarget.h"
 #import "ACRView.h"
+#import "BaseActionElement.h"
 #import <XCTest/XCTest.h>
+
+/// The designated initializer lives in ACOActionOverflowPrivate.h, but that header
+/// re-declares the whole @interface rather than using a class extension, so it cannot be
+/// imported alongside the public ACOActionOverflow.h — which ACROverflowTarget.h above
+/// already brings in. Declaring just the one initializer here keeps the two out of
+/// conflict; the implementation is in ACOActionOverflow.mm.
+@interface ACOActionOverflow (ACROverflowTargetTests)
+- (instancetype)initWithBaseActionElements:(const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>> &)elements
+                                    atCard:(ACOAdaptiveCard *)card;
+@end
 
 @interface ACROverflowTargetTests : XCTestCase
 @end


### PR DESCRIPTION
## Problem

`ACROverflowTarget` presents the overflow action sheet with `handler:nil` on its Cancel action, and posts no accessibility notification when the sheet is dismissed. Nothing tells iOS where VoiceOver focus should land, so it falls back to the platform default — the top of the card — instead of the control the user opened the menu from.

`ACRShowCardTarget` already handles the equivalent case by posting `UIAccessibilityLayoutChangedNotification` with an explicit anchor view. This applies that same established pattern to the overflow menu.

## Change

- `ACROverflowTarget` gains a weak `accessibilityFocusAnchor` property.
- `ACRActionOverflowRenderer` sets it to the button that opened the menu.
- The Cancel handler posts `UIAccessibilityLayoutChangedNotification` against that anchor.

Weak, so the target never keeps the button alive. Nil-checked, so a released anchor posts nothing rather than an unanchored notification.

Three files, +19/-1. No behaviour change for cards without an overflow menu.

## Evidence — and what it does not cover

VoiceOver element scan of the overflow scenario across three states, captured through the real `UIAccessibility` API (`XCUIElement`) on an iOS simulator:

| state | elements | hittable buttons |
|---|---|---|
| before open | 41 | 8 |
| menu open | 41 | **0** |
| after cancel | 41 | 8 |

Hittable buttons going `8 → 0 → 8` confirms the sheet really is presented and really is dismissed. The `after cancel` tree is byte-identical to `before open`, so this change introduces no regression to the card's accessibility tree.

**What this does not show.** The harness records `label / role / frame / isHittable / isEnabled / isSelected / value`. It does **not** record which element holds VoiceOver focus, and the action sheet is presented in a separate `UIWindow` that the scan does not traverse — note `Cancel` never appears in any of the three dumps.

So the focus restoration itself is argued from code inspection and from the existing `ACRShowCardTarget` precedent — it is **not** measured here. Calling that out plainly rather than implying a measurement that was not taken. Confirming it end to end needs VoiceOver driven on a physical device.

### Annotated overlays

Before opening the menu:

![before](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5536765_actionmode_cancel_before.png)

Menu open:

![open](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5536765_actionmode_cancel_after.png)

After cancel:

![after dismiss](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5536765_actionmode_cancel_afterdismiss.png)

Raw per-element dumps:
- [before](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5536765_actionmode_cancel_before_elements.json)
- [open](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5536765_actionmode_cancel_after_elements.json)
- [after cancel](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5536765_actionmode_cancel_afterdismiss_elements.json)

## Scope

One behaviour: where VoiceOver focus goes when the overflow menu is cancelled. Cards without an overflow menu are unaffected, and the anchor is nil-safe.

Work item: **AB#5536765** (A11yMAS)
