### PR TITLE
fix(shared): keep link text out of an input's accessible name via labelFor

### DIFF
--- a/source/shared/cpp/ObjectModel/RichTextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/RichTextBlock.cpp
@@ -87,6 +87,15 @@ std::shared_ptr<BaseCardElement> RichTextBlockParser::Deserialize(ParseContext& 
             if (item->GetInlineType() == InlineElementType::TextRun)
             {
                 auto textRun = std::static_pointer_cast<TextRun>(item);
+                // A run carrying a selectAction is an independently focusable, activatable
+                // link. Folding its text into the labelled input's accessible name makes a
+                // screen reader announce that wording as part of the field name - where it
+                // cannot be activated - and then announce it a second time on reaching the
+                // link itself. Skip those runs; the link remains reachable in its own right.
+                if (textRun->GetSelectAction() != nullptr)
+                {
+                    continue;
+                }
                 label += textRun->GetText() + " ";
             } else if (item->GetInlineType() == InlineElementType::CitationRun) {
                 auto citationRun = std::static_pointer_cast<CitationRun>(item);


### PR DESCRIPTION
## Problem

`RichTextBlockParser` flattens **every** `TextRun` into the label it registers for the input named by `labelFor` — including runs that carry a `selectAction`:

```cpp
for (const auto &item: richTextBlock->m_inlines)
{
    if (item->GetInlineType() == InlineElementType::TextRun)
    {
        auto textRun = std::static_pointer_cast<TextRun>(item);
        label += textRun->GetText() + " ";       // selectAction runs included
    }
    ...
}
TextInput::addLabel(richTextBlock->m_labelFor, label);
```

A run with a `selectAction` is an independently focusable, activatable link. Folding its wording into the labelled input's accessible name means a screen-reader user hears that text **as part of the field's name**, where it cannot be activated — and then hears it a **second time** on reaching the actual link.

In `samples/v1.5/Elements/InputLabel.json` two text fields were named:

```
'RichTextBlock 4 This is the first text run.  Click here for action. This is the second text run.'
```

`Click here for action.` is a link. It is not part of the field's name.

## Change

Skip runs carrying a `selectAction` when building that label. The link itself is untouched and remains reachable and activatable in its own right.

One file, +9 lines. This is in `source/shared/cpp/ObjectModel/`, so it corrects the same defect on Android.

## Evidence

VoiceOver element scan of `samples/v1.5/Elements/InputLabel.json` through the real `UIAccessibility` API (`XCUIElement`) on an iOS simulator, against an **otherwise identical control build** — same harness commit, one file different.

| | elements | polluted field names | links |
|---|---|---|---|
| control (without this change) | 34 | **2** | 4 |
| with this change | 34 | **0** | 4 |

The two field names, before and after:

```
before   'RichTextBlock 4 This is the first text run.  Click here for action. This is the second…'
after    'RichTextBlock 4 This is the first text run.  This is the second text run.'

before   'RichTextBlock 2 This is the first text run.  Click here for action. This is the second…'
after    'RichTextBlock 2 This is the first text run.  This is the second text run.'
```

The link wording is removed; the rest of each label is preserved intact. **No field is left with an empty name.**

Three things this deliberately checks, because a fix in shared parsing code can easily overreach:

1. **The links survive.** `links = 4` in both runs, each still named `Click here for action.` — the fix removes duplicate *naming*, not the link.
2. **Only the intended elements move.** A full tree diff shows exactly 2 removed and 2 added, all four being the two field names above. Element count is unchanged at 34.
3. **No collateral damage.** All **17** other scenarios in the suite are byte-identical between the two runs, including every other input, ChoiceSet, ShowCard and RTL scenario.

### Annotated overlays

Before:

![before](https://raw.githubusercontent.com/hggzm/Teams-AdaptiveCards-Mobile/proxy/evidence-assets/5539188/before_annotated.png)

After:

![after](https://raw.githubusercontent.com/hggzm/Teams-AdaptiveCards-Mobile/proxy/evidence-assets/5539188/after_annotated.png)

Raw per-element dumps:
[before](https://raw.githubusercontent.com/hggzm/Teams-AdaptiveCards-Mobile/proxy/evidence-assets/5539188/before_elements.json) ·
[after](https://raw.githubusercontent.com/hggzm/Teams-AdaptiveCards-Mobile/proxy/evidence-assets/5539188/after_elements.json)

## Note for reviewers

This sits in shared C++ rather than the iOS renderer, because that is where the defect is — the polluted string is produced at parse time and handed to both platforms. Two earlier attempts at fixing this in `ACRInputLabelView.mm` measured as exact no-ops, which is what led to instrumenting the label sources and finding the real origin here.

Worth knowing while reading: `inputIdToLabelMap` is a plain map, so when two RichTextBlocks declare the same `labelFor` the last one wins. That is why the sample's field is named from `RichTextBlock 4` rather than `RichTextBlock 1`. Pre-existing behaviour, unchanged by this PR.

Work item: **AB#5539188** (A11yMAS)
