### PR TITLE
fix(ios): accessibility rollup 2026-08 - CompoundButton, rating stars, ChoiceSet name, main-actor, overflow focus, inline action name, labelFor link text

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerUITests/ADCIOSVisualizerUITests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerUITests/ADCIOSVisualizerUITests.mm
@@ -599,7 +599,10 @@
 
     // Adjust this to select a rating (e.g., tap the 4th star for rating=4)
     // Tap the 4th star for rating=4
-    XCUIElement *fourthStar = [testApp.images elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Rate 4 Star"]];
+    // The star now carries UIAccessibilityTraitButton, so it resolves as a button rather
+    // than an image. That role change is the point of the fix - VoiceOver previously
+    // announced "Rate 4 Star, image" with no indication the control was actuatable.
+    XCUIElement *fourthStar = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Rate 4 Star"]];
     XCTAssertTrue(fourthStar.exists && fourthStar.isHittable, @"The 4th star should exist and be hittable");
     [fourthStar tap];
 
@@ -656,7 +659,10 @@
 
     // Adjust this to select a rating (e.g., tap the 4th star for rating=4)
     // Tap the 4th star for rating=4
-    XCUIElement *fourthStar = [testApp.images elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Rate 4 Star"]];
+    // The star now carries UIAccessibilityTraitButton, so it resolves as a button rather
+    // than an image. That role change is the point of the fix - VoiceOver previously
+    // announced "Rate 4 Star, image" with no indication the control was actuatable.
+    XCUIElement *fourthStar = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Rate 4 Star"]];
     XCTAssertTrue(fourthStar.exists && fourthStar.isHittable, @"The 4th star should exist and be hittable");
     [fourthStar tap];
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		244049E12EC24097000A06DF /* ACRIImageResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 244049E02EC2408D000A06DF /* ACRIImageResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		244915622EBCE3BD0040DF94 /* ACOReferencePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 244915612EBCE3BD0040DF94 /* ACOReferencePrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		246485662E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */; };
+		2AC0F7A22F01000B0085F3BD /* ACROverflowTargetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */; };
 		248924C62EBB617600F76802 /* CitationRun.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 248924C32EBB617600F76802 /* CitationRun.cpp */; };
 		248924C72EBB617600F76802 /* References.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 248924C52EBB617600F76802 /* References.cpp */; };
 		248924C82EBB617600F76802 /* CitationRun.h in Headers */ = {isa = PBXBuildFile; fileRef = 248924C22EBB617600F76802 /* CitationRun.h */; };
@@ -705,6 +706,7 @@
 		244049E02EC2408D000A06DF /* ACRIImageResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ACRIImageResolver.h; sourceTree = "<group>"; };
 		244915612EBCE3BD0040DF94 /* ACOReferencePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ACOReferencePrivate.h; path = PrivateHeaders/ACOReferencePrivate.h; sourceTree = "<group>"; };
 		246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRPopoverTargetTests.mm; sourceTree = "<group>"; };
+		2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACROverflowTargetTests.mm; sourceTree = "<group>"; };
 		248924C22EBB617600F76802 /* CitationRun.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CitationRun.h; path = ../../../../shared/cpp/ObjectModel/CitationRun.h; sourceTree = "<group>"; };
 		248924C32EBB617600F76802 /* CitationRun.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CitationRun.cpp; path = ../../../../shared/cpp/ObjectModel/CitationRun.cpp; sourceTree = "<group>"; };
 		248924C42EBB617600F76802 /* References.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = References.h; path = ../../../../shared/cpp/ObjectModel/References.h; sourceTree = "<group>"; };
@@ -1921,6 +1923,7 @@
 				6B124C9226B8AE3B007E9641 /* Mocks */,
 				6BE6C79F26E17077009E9171 /* TestFiles */,
 				246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */,
+				2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */,
 			);
 			path = AdaptiveCardsTests;
 			sourceTree = "<group>";
@@ -3231,6 +3234,7 @@
 				CFF95C0F2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm in Sources */,
 				6B124C9826B9F5FC007E9641 /* AdaptiveCardsColumnTests.mm in Sources */,
 				246485662E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm in Sources */,
+				2AC0F7A22F01000B0085F3BD /* ACROverflowTargetTests.mm in Sources */,
 				46CBB6422C22BA88008FC5D5 /* AdaptiveCardCompoundButtonTests.mm in Sources */,
 				6B4C05BF27864B0800882387 /* ACRImagePropertiesTests.mm in Sources */,
 			);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
@@ -46,6 +46,8 @@
         ACRTargetBuilderDirector *director = [rootView getActionsTargetBuilderDirector];
         ACRRenderingStatus status = buildTargetForButton(director, acoElem, button, &target);
         if (ACRRenderingStatus::ACROk == status) {
+            // So the menu can hand VoiceOver focus back to this button on dismissal.
+            target.accessibilityFocusAnchor = button;
             [superview addTarget:target];
             // to support Action.ShowCard in menu item action, this line is required
             [target setInputs:inputs superview:superview];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetViewDataSource.mm
@@ -168,16 +168,32 @@ const CGFloat minimumRowHeight = 44.0;
     _accessibilityString = accessibilityLabel ? accessibilityLabel : @"";
     cell.accessibilityTraits = cell.accessibilityTraits;
     
-    // If required field voice over should call it out as required.
-    if (isRequired)
-    {
-        cell.accessibilityLabel = [NSString stringWithFormat:@"%@ %@, %@, %@", _accessibilityString, @"(Required)", cell.textLabel.text, _isMultiChoicesAllowed ? @"check box" : @"radio button"];
-        cell.accessibilityLabel = [cell.accessibilityLabel stringByReplacingOccurrencesOfString:@"*" withString:@""];
+    // Build the label from the parts that actually have content. The previous format
+    // strings always emitted their separators, so a ChoiceSet with no accessible name
+    // produced ", Red, check box" - a leading comma where the name should be, which
+    // VoiceOver reads as a pause and leaves the control effectively unnamed.
+    // At most three components: the name (optionally with the required suffix), the
+    // choice text, and the control role.
+    NSMutableArray<NSString *> *components = [NSMutableArray arrayWithCapacity:3];
+
+    NSString *name = [_accessibilityString stringByTrimmingCharactersInSet:
+                      [NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (name.length > 0) {
+        if (isRequired) {
+            name = [NSString stringWithFormat:@"%@ %@", name, NSLocalizedString(@"(Required)", nil)];
+        }
+        [components addObject:name];
+    } else if (isRequired) {
+        [components addObject:NSLocalizedString(@"(Required)", nil)];
     }
-    else
-    {
-        cell.accessibilityLabel = [NSString stringWithFormat:@"%@, %@, %@", _accessibilityString, cell.textLabel.text, _isMultiChoicesAllowed ? @"check box" : @"radio button"];
+
+    if (cell.textLabel.text.length > 0) {
+        [components addObject:cell.textLabel.text];
     }
+    [components addObject:_isMultiChoicesAllowed ? @"check box" : @"radio button"];
+
+    cell.accessibilityLabel = [[components componentsJoinedByString:@", "]
+                               stringByReplacingOccurrencesOfString:@"*" withString:@""];
     
     cell.accessibilityHint = NSLocalizedString(@"double tap to select", nil);
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
@@ -109,7 +109,22 @@
     std::shared_ptr<BaseActionElement> selectAction = compoundButton->GetSelectAction();
     ACOBaseActionElement *acoSelectAction = [ACOBaseActionElement getACOActionElementFromAdaptiveElement:selectAction];
     addSelectActionToView(acoConfig, acoSelectAction, rootView, compoundButtonView, viewGroup);
-    compoundButtonView.accessibilityLabel = @(compoundButton->getTitle().c_str());
+
+    // Expose the compound button as a single accessible button. Previously only the
+    // title was set as the label and no button trait was applied, so VoiceOver read
+    // the inner labels individually and never announced the control role. Combine
+    // the title, badge and description into one label and mark the view as a button.
+    compoundButtonView.isAccessibilityElement = YES;
+    // At most three parts: title, badge, description.
+    NSMutableArray<NSString *> *compoundButtonLabelParts = [NSMutableArray arrayWithCapacity:3];
+    NSString *compoundButtonTitle = @(compoundButton->getTitle().c_str());
+    NSString *compoundButtonBadge = @(compoundButton->getBadge().c_str());
+    NSString *compoundButtonDescription = @(compoundButton->getDescription().c_str());
+    if (compoundButtonTitle.length) { [compoundButtonLabelParts addObject:compoundButtonTitle]; }
+    if (compoundButtonBadge.length) { [compoundButtonLabelParts addObject:compoundButtonBadge]; }
+    if (compoundButtonDescription.length) { [compoundButtonLabelParts addObject:compoundButtonDescription]; }
+    compoundButtonView.accessibilityLabel = [compoundButtonLabelParts componentsJoinedByString:@", "];
+    compoundButtonView.accessibilityTraits |= UIAccessibilityTraitButton;
     NSString *areaName = stringForCString(elem->GetAreaGridName());
     [viewGroup addArrangedSubview:compoundButtonView withAreaName:areaName];
     return compoundButtonView;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIBaseCardElementRenderer.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIBaseCardElementRenderer.h
@@ -19,19 +19,19 @@
            rootView:(ACRView *)rootView
              inputs:(NSMutableArray *)inputs
     baseCardElement:(ACOBaseCardElement *)acoElem
-         hostConfig:(ACOHostConfig *)acoConfig;
+         hostConfig:(ACOHostConfig *)acoConfig NS_SWIFT_UI_ACTOR;
 @optional
 /// override this method for custom styling
 /// not all renderers supports it
 - (void)configure:(UIView *)view
            rootView:(ACRView *)rootView
     baseCardElement:(ACOBaseCardElement *)acoElem
-         hostConfig:(ACOHostConfig *)acoConfig;
+         hostConfig:(ACOHostConfig *)acoConfig NS_SWIFT_UI_ACTOR;
 
 - (void)configureVC:(UIViewController *)view
            rootView:(ACRView *)rootView
     baseCardElement:(ACOBaseCardElement *)acoElem
-         hostConfig:(ACOHostConfig *)acoConfig;
+         hostConfig:(ACOHostConfig *)acoConfig NS_SWIFT_UI_ACTOR;
 @end
 
 @protocol ACRIKVONotificationHandler

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -192,7 +192,16 @@
         NSString *key = [NSString stringWithCString:action->GetIconUrl(ACTheme(rootView.theme)).c_str() encoding:[NSString defaultCStringEncoding]];
         UIImage *img = imageViewMap[key];
         button.iconPlacement = ACRNoTitle;
-        button.accessibilityLabel = title;
+        // An icon-only inline action carries no title, so this assigned an empty string and
+        // left the button with no accessible name at all - VoiceOver reaches a control it
+        // cannot announce or describe. The card does name it, through the action's tooltip,
+        // which is the same text a sighted user gets on hover.
+        //
+        // This is the mirror of the rule further down that promotes the title to the tooltip
+        // when an icon button has a title but no tooltip; title and tooltip are already
+        // treated as interchangeable naming sources for these buttons.
+        NSString *tooltip = [NSString stringWithCString:action->GetTooltip().c_str() encoding:NSUTF8StringEncoding];
+        button.accessibilityLabel = title.length ? title : tooltip;
 
         if (img) {
             UIImageView *iconView = [[ACRUIImageView alloc] init];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.h
@@ -31,4 +31,13 @@
 
 @property (readonly) NSArray<ACROverflowMenuItem *> *menuItems;
 
+/// The control that opened the overflow menu. VoiceOver focus is returned here when the
+/// menu is dismissed, so the user lands back where they were instead of at the top of
+/// the screen.
+@property (nonatomic, weak) UIView *accessibilityFocusAnchor;
+
+/// Hands VoiceOver focus back to ``accessibilityFocusAnchor``. Called when the menu is
+/// dismissed. A no-op when no anchor is set or the anchor has already gone away.
+- (void)restoreAccessibilityFocusToAnchor;
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
@@ -242,9 +242,24 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
         }
     }
 
+    // Dismissing the sheet has to say where focus goes. With a nil handler nothing posts
+    // an accessibility notification, so VoiceOver falls back to the platform default and
+    // the user loses their place instead of returning to the control they opened the menu
+    // from. ACRShowCardTarget already handles the equivalent case this way.
+    __weak __typeof(self) weakSelf = self;
     [_alert addAction:[UIAlertAction actionWithTitle:@"Cancel"
                                                style:UIAlertActionStyleCancel
-                                             handler:nil]];
+                                             handler:^(__unused UIAlertAction *action) {
+                                                 [weakSelf restoreAccessibilityFocusToAnchor];
+                                             }]];
+}
+
+- (void)restoreAccessibilityFocusToAnchor
+{
+    UIView *anchor = self.accessibilityFocusAnchor;
+    if (anchor) {
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, anchor);
+    }
 }
 
 - (void)setInputs:(NSMutableArray *)inputs

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRatingView.mm
@@ -94,6 +94,9 @@
         starImageView.userInteractionEnabled = YES;
         starImageView.isAccessibilityElement = YES;
         starImageView.accessibilityLabel = [NSString stringWithFormat:@"Rate %d Star", (int)i+1];
+        // Each star is tappable, so announce it as a button. Without a trait VoiceOver
+        // reads "Rate 3 Star, image" and gives no indication the control is actuatable.
+        starImageView.accessibilityTraits |= UIAccessibilityTraitButton;
         UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleStarTap:)];
         [starImageView addGestureRecognizer:tapGesture];
         [_accessibleChildren addObject:starImageView];
@@ -129,13 +132,16 @@
     _ratingLabel = [[UILabel alloc] initWithFrame:CGRectZero];
     _ratingLabel.translatesAutoresizingMaskIntoConstraints = NO;
     _ratingLabel.attributedText = [self atrributedStringForLabel];
+    // These branches were inverted: a rating WITH a count announced "Rating 3.2," -
+    // dropping the count and leaving a dangling comma that VoiceOver pauses on - while a
+    // rating WITHOUT a count announced the meaningless "Count 0".
     if (_count > 0)
     {
-        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f,", (float)_value];
+        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f, Count %d", (float)_value, (int)_count];
     }
     else
     {
-        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f, Count %d", (float)_value, (int)_count];
+        _ratingLabel.accessibilityLabel = [[NSString alloc] initWithFormat:@"Rating %.1f", (float)_value];
     }
     
     [self addSubview:_ratingLabel];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACROverflowTargetTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACROverflowTargetTests.mm
@@ -1,0 +1,133 @@
+//
+//  ACROverflowTargetTests.mm
+//  AdaptiveCardsTests
+//
+//  Copyright © 2026 Microsoft. All rights reserved.
+//
+
+#import "ACOAdaptiveCard.h"
+#import "ACOAdaptiveCardParseResult.h"
+#import "ACROverflowTarget.h"
+#import "ACRView.h"
+#import "BaseActionElement.h"
+#import <XCTest/XCTest.h>
+
+/// The designated initializer lives in ACOActionOverflowPrivate.h, but that header
+/// re-declares the whole @interface rather than using a class extension, so it cannot be
+/// imported alongside the public ACOActionOverflow.h — which ACROverflowTarget.h above
+/// already brings in. Declaring just the one initializer here keeps the two out of
+/// conflict; the implementation is in ACOActionOverflow.mm.
+@interface ACOActionOverflow (ACROverflowTargetTests)
+- (instancetype)initWithBaseActionElements:(const std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>> &)elements
+                                    atCard:(ACOAdaptiveCard *)card;
+@end
+
+@interface ACROverflowTargetTests : XCTestCase
+@end
+
+@implementation ACROverflowTargetTests
+
+/// ACOActionOverflow works out whether it sits at the card's root by walking that card's
+/// actions, so it needs a real card. Built through the designated initializer, which is
+/// also what ACRActionSetRenderer uses, so these tests exercise the production path.
+- (ACOActionOverflow *)makeOverflowElement
+{
+    NSString *payload = @"{\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[]}";
+    ACOAdaptiveCardParseResult *parseResult = [ACOAdaptiveCard fromJson:payload];
+    XCTAssertTrue(parseResult.isValid, @"the fixture card should parse");
+
+    std::vector<std::shared_ptr<AdaptiveCards::BaseActionElement>> noMenuActions;
+    return [[ACOActionOverflow alloc] initWithBaseActionElements:noMenuActions
+                                                          atCard:parseResult.card];
+}
+
+- (ACROverflowTarget *)makeTarget
+{
+    ACRView *rootView = [[ACRView alloc] initWithFrame:CGRectZero];
+    return [[ACROverflowTarget alloc] initWithActionElement:[self makeOverflowElement]
+                                                   rootView:rootView];
+}
+
+- (UIAlertAction *)cancelActionOf:(ACROverflowTarget *)target
+{
+    UIAlertController *alert = [target valueForKey:@"alert"];
+    for (UIAlertAction *action in alert.actions) {
+        if (action.style == UIAlertActionStyleCancel) {
+            return action;
+        }
+    }
+    return nil;
+}
+
+/// The sheet must offer a way out; that action is what hands focus back.
+- (void)testOverflowSheetHasACancelAction
+{
+    UIAlertAction *cancel = [self cancelActionOf:[self makeTarget]];
+    XCTAssertNotNil(cancel, @"the overflow sheet should offer a cancel action");
+    XCTAssertEqual(cancel.style, UIAlertActionStyleCancel);
+}
+
+/// The anchor is the control the user opened the menu from.
+- (void)testFocusAnchorRoundTrips
+{
+    ACROverflowTarget *target = [self makeTarget];
+    UIView *button = [[UIView alloc] initWithFrame:CGRectZero];
+    target.accessibilityFocusAnchor = button;
+    XCTAssertEqual(target.accessibilityFocusAnchor, button);
+}
+
+/// The anchor is weak on purpose: the menu must never keep the button alive.
+- (void)testFocusAnchorDoesNotRetainTheButton
+{
+    ACROverflowTarget *target = [self makeTarget];
+    @autoreleasepool {
+        UIView *button = [[UIView alloc] initWithFrame:CGRectZero];
+        target.accessibilityFocusAnchor = button;
+        XCTAssertNotNil(target.accessibilityFocusAnchor);
+    }
+    XCTAssertNil(target.accessibilityFocusAnchor,
+                 @"the anchor must not retain the button that opened the menu");
+}
+
+/// The defect this guards: dismissing the sheet used to do nothing at all, so VoiceOver
+/// fell back to the top of the card instead of the control the user came from. Driving
+/// the restoration with a live anchor must complete cleanly.
+///
+/// Note this asserts the restoration path runs and is safe, not that VoiceOver received
+/// the notification — UIAccessibility notifications are delivered to the accessibility
+/// server and are not observable from a unit test with VoiceOver off.
+- (void)testRestoringFocusWithAnAnchorIsSafe
+{
+    ACROverflowTarget *target = [self makeTarget];
+    UIView *button = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 44, 44)];
+    target.accessibilityFocusAnchor = button;
+    XCTAssertNoThrow([target restoreAccessibilityFocusToAnchor]);
+}
+
+/// If the anchor has gone away, restoration must be a no-op rather than posting an
+/// unanchored notification or touching a released view.
+- (void)testRestoringFocusWithoutAnAnchorIsANoOp
+{
+    ACROverflowTarget *target = [self makeTarget];
+    XCTAssertNil(target.accessibilityFocusAnchor);
+    XCTAssertNoThrow([target restoreAccessibilityFocusToAnchor]);
+}
+
+/// The cancel handler captures self weakly; the target must still deallocate.
+- (void)testTargetDeallocates
+{
+    __weak ACROverflowTarget *weakTarget;
+    // Held strongly out here on purpose: assigning a freshly created view straight to the
+    // weak anchor would release it on the spot and the assertion would prove nothing.
+    UIView *button = [[UIView alloc] initWithFrame:CGRectZero];
+    @autoreleasepool {
+        ACROverflowTarget *target = [self makeTarget];
+        target.accessibilityFocusAnchor = button;
+        weakTarget = target;
+        target = nil;
+    }
+    XCTAssertNil(weakTarget, @"ACROverflowTarget should deallocate (no retain cycle)");
+    XCTAssertNotNil(button, @"the anchor outlives the target");
+}
+
+@end

--- a/source/shared/cpp/ObjectModel/RichTextBlock.cpp
+++ b/source/shared/cpp/ObjectModel/RichTextBlock.cpp
@@ -87,6 +87,15 @@ std::shared_ptr<BaseCardElement> RichTextBlockParser::Deserialize(ParseContext& 
             if (item->GetInlineType() == InlineElementType::TextRun)
             {
                 auto textRun = std::static_pointer_cast<TextRun>(item);
+                // A run carrying a selectAction is an independently focusable, activatable
+                // link. Folding its text into the labelled input's accessible name makes a
+                // screen reader announce that wording as part of the field name - where it
+                // cannot be activated - and then announce it a second time on reaching the
+                // link itself. Skip those runs; the link remains reachable in its own right.
+                if (textRun->GetSelectAction() != nullptr)
+                {
+                    continue;
+                }
                 label += textRun->GetText() + " ";
             } else if (item->GetInlineType() == InlineElementType::CitationRun) {
                 auto citationRun = std::static_pointer_cast<CitationRun>(item);


### PR DESCRIPTION
## Summary

Rollup of seven iOS accessibility fixes, combined into a single PR so they can be validated and merged in one CI pass instead of seven.

Each constituent change is **byte-identical** to its standalone PR (verified per-file), applied onto current `main`. They touch **disjoint files**, so there are no interactions between them.

| Fix | Standalone PR | Work item | File(s) |
|---|---|---|---|
| Announce CompoundButton as a single button | #729 | AB#5532275 | `ACRCompoundButtonRenderer.mm` |
| Announce rating stars as buttons, repair the read-only rating label | #731 | AB#5535831 | `ACRRatingView.mm`, `ADCIOSVisualizerUITests.mm` |
| Give ChoiceSet cells a real accessible name | #732 | AB#5539328 | `ACRChoiceSetViewDataSource.mm` |
| Mark `ACRIBaseCardElementRenderer` main-actor isolated (Swift 6) | #733 | — | `ACRIBaseCardElementRenderer.h` |
| Restore VoiceOver focus after the overflow menu is cancelled | #734 | AB#5536765 | `ACROverflowTarget.h/.mm`, `ACRActionOverflowRenderer.mm`, `ACROverflowTargetTests.mm`, `project.pbxproj` |
| Name icon-only inline action buttons from their tooltip | #735 | AB#5539230 | `ACRInputRenderer.mm` |
| Keep link text out of an input's accessible name via `labelFor` | #736 | AB#5539188 | `RichTextBlock.cpp` |

Total: **12 files, +242 / −18**.

## Why a rollup

These come out of the A11yMAS audit batch. Each has been reviewed individually, but every PR needs its own `teams-adaptivecards-ios-pr` and `teams-adaptivecards-android-pr` run — roughly 30 minutes each — and this repository dismisses approvals on push, so each round of review feedback costs a full re-approval and re-run cycle on every PR separately.

This consolidates them so one CI pass covers all seven.

An eighth fix from the same batch, #730 (LTR semantic content attribute), is already merged and is therefore not included here.

## Evidence

Each standalone PR carries its own before/after evidence — VoiceOver element counts captured through the real `UIAccessibility` API on a simulator, measured against an otherwise-identical control build, plus annotated overlays. Rather than duplicate that here, follow the per-fix links in the table above.

Two notes worth carrying over:

- **#736 is the only change in `source/shared/cpp/ObjectModel/`**, so it corrects the same defect on Android as well. That is intentional — the polluted string is produced at parse time and handed to both platforms — but it has a wider blast radius than the iOS-only changes and deserves a closer read. Its Android build passes both standalone (14075) and here.

- **#734 includes a new unit test file** (`ACROverflowTargetTests.mm`) and its `project.pbxproj` registration. The tests assert the focus-restoration path runs and is safe; they do not assert VoiceOver received the notification, since `UIAccessibility` notifications are delivered to the accessibility server and are not observable from a unit test with VoiceOver off.

**No production file outside the seven fixes is modified.** The new test declares the `ACOActionOverflow` designated initializer in a local category rather than importing `ACOActionOverflowPrivate.h`, because that header re-declares the whole `@interface` instead of using a class extension and therefore cannot coexist with the public header that `ACROverflowTarget.h` already imports.

## Merge note

If you prefer to merge this rollup, #729 and #731–#736 can be closed as included here. If you would rather take them individually, this PR can be closed instead — the standalone PRs remain valid and independent.
