### PR TITLE
[iOS][Fix] Luminosity issue fix

### DIFF
--- a/samples/HostConfig/microsoft-teams-dark.json
+++ b/samples/HostConfig/microsoft-teams-dark.json
@@ -370,7 +370,7 @@
 			"tint": {
 				"backgroundColor": "#2f2f4a",
 				"strokeColor": "#292929",
-				"textColor": "#7f85f5"
+				"textColor": "#a6a7dc"
 			}
 		},
 		"attention": {
@@ -382,7 +382,7 @@
 			"tint": {
 				"backgroundColor": "#250909",
 				"strokeColor": "#292929",
-				"textColor": "#e83a3a"
+				"textColor": "#f1707b"
 			}
 		},
 		"good": {
@@ -401,12 +401,12 @@
 			"filled": {
 				"backgroundColor": "#292929",
 				"strokeColor": "#292929",
-				"textColor": "#919191"
+				"textColor": "#adadad"
 			},
 			"tint": {
 				"backgroundColor": "#212121",
 				"strokeColor": "#292929",
-				"textColor": "#919191"
+				"textColor": "#adadad"
 			}
 		},
 		"subtle": {

--- a/samples/HostConfig/microsoft-teams-light.json
+++ b/samples/HostConfig/microsoft-teams-light.json
@@ -370,7 +370,7 @@
 			"tint": {
 				"backgroundColor": "#e8ebfa",
 				"strokeColor": "#e1e1e1",
-				"textColor": "#5b5fc7"
+				"textColor": "#444791"
 			}
 		},
 		"attention": {
@@ -382,7 +382,7 @@
 			"tint": {
 				"backgroundColor": "#f9d9d9",
 				"strokeColor": "#e1e1e1",
-				"textColor": "#d92c2c"
+				"textColor": "#a4262c"
 			}
 		},
 		"good": {
@@ -394,7 +394,7 @@
 			"tint": {
 				"backgroundColor": "#e7f2da",
 				"strokeColor": "#e1e1e1",
-				"textColor": "#0f7a0b"
+				"textColor": "#0b6a0b"
 			}
 		},
 		"informative": {
@@ -413,12 +413,12 @@
 			"filled": {
 				"backgroundColor": "#f1f1f1",
 				"strokeColor": "#f1f1f1",
-				"textColor": "#6e6e6e"
+				"textColor": "#5f5f5f"
 			},
 			"tint": {
 				"backgroundColor": "#f1f1f1",
 				"strokeColor": "#e1e1e1",
-				"textColor": "#6e6e6e"
+				"textColor": "#5f5f5f"
 			}
 		},
 		"warning": {

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -916,6 +916,7 @@
 		6BE6C7A426E17132009E9171 /* ColumnSet.VerticalStretch.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = ColumnSet.VerticalStretch.json; path = ../../../../../../samples/v1.1/Tests/ColumnSet.VerticalStretch.json; sourceTree = "<group>"; };
 		6BE6C7AE26E2C969009E9171 /* ACRCustomRenderers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ACRCustomRenderers.h; sourceTree = "<group>"; };
 		6BE6C7AF26E2C9A3009E9171 /* ACRCustomRenderers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRCustomRenderers.mm; sourceTree = "<group>"; };
+		A11C0A572F51000100C0A57A /* ACRContrastTestUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ACRContrastTestUtils.h; sourceTree = "<group>"; };
 		6BE6C7B126E2DF29009E9171 /* Container.VerticalContentAlignment2.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Container.VerticalContentAlignment2.json; sourceTree = "<group>"; };
 		6BE6C7B526E2E140009E9171 /* Column.VerticalAlignment.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Column.VerticalAlignment.json; sourceTree = "<group>"; };
 		6BE6C7B726E2E30A009E9171 /* Container.VerticalContentAlignment.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Container.VerticalContentAlignment.json; sourceTree = "<group>"; };
@@ -1600,6 +1601,7 @@
 		6BE6C79426E1560A009E9171 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				A11C0A572F51000100C0A57A /* ACRContrastTestUtils.h */,
 				6BE6C7AE26E2C969009E9171 /* ACRCustomRenderers.h */,
 				6BE6C7AF26E2C9A3009E9171 /* ACRCustomRenderers.mm */,
 			);

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
@@ -8,6 +8,7 @@
 #import "ACRChoiceSetCompactStyleView.h"
 #import "ACOBaseCardElementPrivate.h"
 #import "ACOBundle.h"
+#import "ACOHostConfigPrivate.h"
 #import "ACRActionDelegate.h"
 #import "ACRBaseCardElementRenderer.h"
 #import "ACRInputLabelView.h"
@@ -107,7 +108,9 @@ static inline CGRect ActiveSceneBoundsForView(UIView *view)
         // configure UITextField
         self.delegate = self;
         self.placeholder = _validator.placeHolder;
-        UIColor *placeholderColor = [UIColor colorWithWhite:0.4 alpha:1.0];
+        UIColor *placeholderColor = [acoConfig getTextBlockColor:ACRDefault
+                                                       textColor:ForegroundColor::Default
+                                                    subtleOption:YES];
         self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.placeholder ?: @""
                                                                      attributes:@{NSForegroundColorAttributeName : placeholderColor}];
         self.allowsEditingTextAttributes = NO;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetCompactStyleView.mm
@@ -107,6 +107,9 @@ static inline CGRect ActiveSceneBoundsForView(UIView *view)
         // configure UITextField
         self.delegate = self;
         self.placeholder = _validator.placeHolder;
+        UIColor *placeholderColor = [UIColor colorWithWhite:0.4 alpha:1.0];
+        self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.placeholder ?: @""
+                                                                     attributes:@{NSForegroundColorAttributeName : placeholderColor}];
         self.allowsEditingTextAttributes = NO;
         self.text = _validator.userInitialChoice;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetFilteredStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetFilteredStyleView.mm
@@ -8,6 +8,7 @@
 #import "ACRChoiceSetFilteredStyleView.h"
 #import "ACOBaseCardElementPrivate.h"
 #import "ACOBundle.h"
+#import "ACOHostConfigPrivate.h"
 #import "ACRActionDelegate.h"
 #import "ACRBaseCardElementRenderer.h"
 #import "ACRChoiceSetCompactStyleView.h"
@@ -57,7 +58,9 @@ using namespace AdaptiveCards;
         // configure UITextField
         self.delegate = self;
         self.placeholder = _validator.placeHolder;
-        UIColor *placeholderColor = [UIColor colorWithWhite:0.4 alpha:1.0];
+        UIColor *placeholderColor = [hostConfig getTextBlockColor:ACRDefault
+                                                       textColor:ForegroundColor::Default
+                                                    subtleOption:YES];
         self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.placeholder ?: @""
                                                                      attributes:@{NSForegroundColorAttributeName : placeholderColor}];
         self.allowsEditingTextAttributes = NO;

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetFilteredStyleView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRChoiceSetFilteredStyleView.mm
@@ -57,6 +57,9 @@ using namespace AdaptiveCards;
         // configure UITextField
         self.delegate = self;
         self.placeholder = _validator.placeHolder;
+        UIColor *placeholderColor = [UIColor colorWithWhite:0.4 alpha:1.0];
+        self.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.placeholder ?: @""
+                                                                     attributes:@{NSForegroundColorAttributeName : placeholderColor}];
         self.allowsEditingTextAttributes = NO;
         self.text = _validator.userInitialChoice;
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextField.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRTextField.mm
@@ -11,7 +11,9 @@
 #import "TextInput.h"
 
 
-@implementation ACRTextField
+@implementation ACRTextField {
+    UIButton *_acrClearButton;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
@@ -46,8 +48,16 @@
     self.font = [UIFont systemFontOfSize:15];
     self.minimumFontSize = 15;
 
-    // Display clear button always
-    self.clearButtonMode = UITextFieldViewModeAlways;
+    self.clearButtonMode = UITextFieldViewModeNever;
+    _acrClearButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    _acrClearButton.tintColor = UIColor.secondaryLabelColor;
+    _acrClearButton.accessibilityLabel = @"Clear text";
+    UIImage *clearImage = [[UIImage systemImageNamed:@"xmark.circle.fill"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    [_acrClearButton setImage:clearImage forState:UIControlStateNormal];
+    [_acrClearButton addTarget:self action:@selector(acr_clearTextField:) forControlEvents:UIControlEventTouchUpInside];
+    self.rightView = _acrClearButton;
+    self.rightViewMode = UITextFieldViewModeNever;
+    [self addTarget:self action:@selector(updateClearButtonVisibility) forControlEvents:UIControlEventEditingChanged];
 
     // Automatically enable the return key when appropriate
     self.enablesReturnKeyAutomatically = YES;
@@ -62,6 +72,33 @@
     } @catch (NSException *exception) {
         // Fallback if the placeholderLabel property is not available.
         NSLog(@"Placeholder text color not set: %@", exception);
+    }
+}
+
+- (CGRect)rightViewRectForBounds:(CGRect)bounds
+{
+    if (self.rightView == _acrClearButton) {
+        return [super clearButtonRectForBounds:bounds];
+    }
+    return [super rightViewRectForBounds:bounds];
+}
+
+- (void)setText:(NSString *)text
+{
+    [super setText:text];
+    [self updateClearButtonVisibility];
+}
+
+- (void)acr_clearTextField:(UIButton *)sender
+{
+    self.text = @"";
+    [self sendActionsForControlEvents:UIControlEventEditingChanged];
+}
+
+- (void)updateClearButtonVisibility
+{
+    if (self.rightView == _acrClearButton) {
+        self.rightViewMode = self.text.length ? UITextFieldViewModeAlways : UITextFieldViewModeNever;
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/AdaptiveCardsTests.mm
@@ -11,6 +11,7 @@
 #import "ACRFactSetRenderer.h"
 #import "ACRInputLabelView.h"
 #import "ACRRegistration.h"
+#import "ACRTextField.h"
 #import "ACRTextView.h"
 #import "ACRViewPrivate.h"
 #import "Fact.h"
@@ -21,6 +22,10 @@
 #import <XCTest/XCTest.h>
 
 using namespace AdaptiveCards;
+
+@interface ACRTextField (Testing)
+- (void)acr_clearTextField:(UIButton *)sender;
+@end
 
 @interface ACRTrackingTextMapView : ACRView
 
@@ -71,6 +76,43 @@ using namespace AdaptiveCards;
 
     std::string serializedTextBlock = textblock->Serialize();
     XCTAssert(serializedTextBlock == "{\"text\":\"Text test\",\"type\":\"TextBlock\"}\n");
+}
+
+- (void)testDefaultBadgeStylesUseAccessibleTextColors
+{
+    HostConfig hostConfig;
+    BadgeStylesDefinition badgeStyles = hostConfig.GetBadgeStyles();
+
+    XCTAssertEqual(badgeStyles.accentPalette.tintStyle.textColor, std::string("#444791"));
+    XCTAssertEqual(badgeStyles.attentionPalette.tintStyle.textColor, std::string("#a4262c"));
+    XCTAssertEqual(badgeStyles.goodPalette.tintStyle.textColor, std::string("#0b6a0b"));
+    XCTAssertEqual(badgeStyles.subtlePalette.filledStyle.textColor, std::string("#5f5f5f"));
+    XCTAssertEqual(badgeStyles.subtlePalette.tintStyle.textColor, std::string("#5f5f5f"));
+}
+
+- (void)testTextFieldClearButtonUsesAccessibleColorAndNativeLayout
+{
+    CGRect bounds = CGRectMake(0, 0, 220, 34);
+    ACRTextField *textField = [[ACRTextField alloc] initWithFrame:bounds];
+    textField.text = @"Ashley";
+
+    UITextField *nativeTextField = [[UITextField alloc] initWithFrame:bounds];
+    nativeTextField.borderStyle = UITextBorderStyleRoundedRect;
+    nativeTextField.clearButtonMode = UITextFieldViewModeAlways;
+
+    XCTAssertEqual(textField.rightViewMode, UITextFieldViewModeAlways);
+    XCTAssertTrue([textField.rightView isKindOfClass:UIButton.class]);
+    XCTAssertTrue(CGRectEqualToRect([textField rightViewRectForBounds:bounds],
+                                    [nativeTextField clearButtonRectForBounds:bounds]));
+
+    UIButton *clearButton = (UIButton *)textField.rightView;
+    XCTAssertEqualObjects(clearButton.tintColor, UIColor.secondaryLabelColor);
+    XCTAssertEqualObjects(clearButton.accessibilityLabel, @"Clear text");
+
+    [textField acr_clearTextField:clearButton];
+
+    XCTAssertEqualObjects(textField.text, @"");
+    XCTAssertEqual(textField.rightViewMode, UITextFieldViewModeNever);
 }
 
 - (void)testContentHoldingUIViewWithImage

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetCompactStyleViewTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetCompactStyleViewTests.mm
@@ -45,8 +45,18 @@ using namespace AdaptiveCards;
 - (ACOBaseCardElement *)buildBaseCardElement
 {
     std::shared_ptr<ChoiceSetInput> choiceSet = std::make_shared<ChoiceSetInput>();
+    choiceSet->SetPlaceholder("Please choose");
     ACOBaseCardElement *acoElem = [[ACOBaseCardElement alloc] initWithBaseCardElement:choiceSet];
     return acoElem;
+}
+
+- (void)testPlaceholderUsesAccessibleColor
+{
+    ACRChoiceSetCompactStyleView *compactStyleView = [[ACRChoiceSetCompactStyleView alloc] initWithInputChoiceSet:[self buildBaseCardElement] rootView:_rootView hostConfig:_hostConfig];
+    UIColor *placeholderColor = [compactStyleView.attributedPlaceholder attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil];
+    UIColor *expectedColor = [UIColor colorWithWhite:0.4 alpha:1.0];
+
+    XCTAssertEqualObjects(placeholderColor, expectedColor);
 }
 
 - (void)testUpdateFilteredListForStaticTypeahead

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetCompactStyleViewTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetCompactStyleViewTests.mm
@@ -11,6 +11,7 @@
 #import "ACOHostConfigPrivate.h"
 #import "ACRButton.h"
 #import "ACRChoiceSetCompactStyleView.h"
+#import "ACRContrastTestUtils.h"
 #import "ACRMockViews.h"
 #import "ACRViewPrivate.h"
 #import "ChoiceSetInput.h"
@@ -50,15 +51,28 @@ using namespace AdaptiveCards;
     return acoElem;
 }
 
-- (void)testPlaceholderUsesAccessibleColor
+- (void)testPlaceholderMeetsContrastRequirement
 {
     ACRChoiceSetCompactStyleView *compactStyleView = [[ACRChoiceSetCompactStyleView alloc] initWithInputChoiceSet:[self buildBaseCardElement] rootView:_rootView hostConfig:_hostConfig];
     UIColor *placeholderColor = [compactStyleView.attributedPlaceholder attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil];
-    UIColor *expectedColor = [_hostConfig getTextBlockColor:ACRDefault
-                                                 textColor:ForegroundColor::Default
-                                              subtleOption:YES];
+    UITraitCollection *lightTraits = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight];
+    UIColor *backgroundColor = [UIColor.systemGroupedBackgroundColor resolvedColorWithTraitCollection:lightTraits];
 
-    XCTAssertEqualObjects(placeholderColor, expectedColor);
+    XCTAssertGreaterThanOrEqual(ACRContrastRatio(placeholderColor, backgroundColor, lightTraits), 4.5);
+}
+
+- (void)testPlaceholderMeetsContrastRequirementInDarkMode
+{
+    NSString *darkHostConfigJson = @"{\"containerStyles\":{\"default\":{\"foregroundColors\":{\"default\":{\"default\":\"#FFFFFFFF\",\"subtle\":\"#BFFFFFFF\"}},\"backgroundColor\":\"#141414\"}}}";
+    ACOHostConfigParseResult *parseResult = [ACOHostConfig fromJson:darkHostConfigJson];
+    XCTAssertTrue(parseResult.isValid);
+
+    ACRChoiceSetCompactStyleView *compactStyleView = [[ACRChoiceSetCompactStyleView alloc] initWithInputChoiceSet:[self buildBaseCardElement] rootView:_rootView hostConfig:parseResult.config];
+    UIColor *placeholderColor = [compactStyleView.attributedPlaceholder attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil];
+    UITraitCollection *darkTraits = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleDark];
+    UIColor *backgroundColor = [UIColor.systemGroupedBackgroundColor resolvedColorWithTraitCollection:darkTraits];
+
+    XCTAssertGreaterThanOrEqual(ACRContrastRatio(placeholderColor, backgroundColor, darkTraits), 4.5);
 }
 
 - (void)testUpdateFilteredListForStaticTypeahead

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetCompactStyleViewTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetCompactStyleViewTests.mm
@@ -54,7 +54,9 @@ using namespace AdaptiveCards;
 {
     ACRChoiceSetCompactStyleView *compactStyleView = [[ACRChoiceSetCompactStyleView alloc] initWithInputChoiceSet:[self buildBaseCardElement] rootView:_rootView hostConfig:_hostConfig];
     UIColor *placeholderColor = [compactStyleView.attributedPlaceholder attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil];
-    UIColor *expectedColor = [UIColor colorWithWhite:0.4 alpha:1.0];
+    UIColor *expectedColor = [_hostConfig getTextBlockColor:ACRDefault
+                                                 textColor:ForegroundColor::Default
+                                              subtleOption:YES];
 
     XCTAssertEqualObjects(placeholderColor, expectedColor);
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetFilteredStyleViewTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetFilteredStyleViewTests.mm
@@ -8,6 +8,7 @@
 
 #import "ACOBaseCardElement.h"
 #import "ACOBaseCardElementPrivate.h"
+#import "ACOHostConfigPrivate.h"
 #import "ACRChoiceSetFilteredStyleView.h"
 #import "ACRMockViews.h"
 #import "ChoiceSetInput.h"
@@ -21,6 +22,7 @@
 @implementation ACRChoiceSetFilteredStyleViewTests {
     MockACRView *_rootView;
     ACOBaseCardElement *_acoElem;
+    ACOHostConfig *_hostConfig;
 }
 
 - (void)setUp
@@ -29,11 +31,12 @@
     std::shared_ptr<ChoiceSetInput> choiceSet = std::make_shared<ChoiceSetInput>();
     choiceSet->SetPlaceholder("Please choose");
     _acoElem = [[ACOBaseCardElement alloc] initWithBaseCardElement:choiceSet];
+    _hostConfig = [[ACOHostConfig alloc] init];
 }
 
 - (void)testFilteredStyleViewInit
 {
-    ACRChoiceSetFilteredStyleView *filteredView = [[ACRChoiceSetFilteredStyleView alloc] initWithInputChoiceSet:_acoElem rootView:_rootView hostConfig:nil searchStateParams:nil typeaheadViewTitle:@"typeahead"];
+    ACRChoiceSetFilteredStyleView *filteredView = [[ACRChoiceSetFilteredStyleView alloc] initWithInputChoiceSet:_acoElem rootView:_rootView hostConfig:_hostConfig searchStateParams:nil typeaheadViewTitle:@"typeahead"];
     XCTAssertNotNil(filteredView.showFilteredListControl);
     NSString *selectedText = [filteredView getSelectedText];
     XCTAssertEqual(selectedText.length, 0);
@@ -50,9 +53,11 @@
 
 - (void)testPlaceholderUsesAccessibleColor
 {
-    ACRChoiceSetFilteredStyleView *filteredView = [[ACRChoiceSetFilteredStyleView alloc] initWithInputChoiceSet:_acoElem rootView:_rootView hostConfig:nil searchStateParams:nil typeaheadViewTitle:@"typeahead"];
+    ACRChoiceSetFilteredStyleView *filteredView = [[ACRChoiceSetFilteredStyleView alloc] initWithInputChoiceSet:_acoElem rootView:_rootView hostConfig:_hostConfig searchStateParams:nil typeaheadViewTitle:@"typeahead"];
     UIColor *placeholderColor = [filteredView.attributedPlaceholder attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil];
-    UIColor *expectedColor = [UIColor colorWithWhite:0.4 alpha:1.0];
+    UIColor *expectedColor = [_hostConfig getTextBlockColor:ACRDefault
+                                                 textColor:ForegroundColor::Default
+                                              subtleOption:YES];
 
     XCTAssertEqualObjects(placeholderColor, expectedColor);
 }

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetFilteredStyleViewTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetFilteredStyleViewTests.mm
@@ -10,6 +10,7 @@
 #import "ACOBaseCardElementPrivate.h"
 #import "ACOHostConfigPrivate.h"
 #import "ACRChoiceSetFilteredStyleView.h"
+#import "ACRContrastTestUtils.h"
 #import "ACRMockViews.h"
 #import "ChoiceSetInput.h"
 #import <UIKit/UIKit.h>
@@ -51,15 +52,14 @@
     XCTAssertFalse(res);
 }
 
-- (void)testPlaceholderUsesAccessibleColor
+- (void)testPlaceholderMeetsContrastRequirement
 {
     ACRChoiceSetFilteredStyleView *filteredView = [[ACRChoiceSetFilteredStyleView alloc] initWithInputChoiceSet:_acoElem rootView:_rootView hostConfig:_hostConfig searchStateParams:nil typeaheadViewTitle:@"typeahead"];
     UIColor *placeholderColor = [filteredView.attributedPlaceholder attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil];
-    UIColor *expectedColor = [_hostConfig getTextBlockColor:ACRDefault
-                                                 textColor:ForegroundColor::Default
-                                              subtleOption:YES];
+    UITraitCollection *lightTraits = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight];
+    UIColor *backgroundColor = [UIColor.systemGroupedBackgroundColor resolvedColorWithTraitCollection:lightTraits];
 
-    XCTAssertEqualObjects(placeholderColor, expectedColor);
+    XCTAssertGreaterThanOrEqual(ACRContrastRatio(placeholderColor, backgroundColor, lightTraits), 4.5);
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetFilteredStyleViewTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/DynamicTypeahead/ACRChoiceSetFilteredStyleViewTests.mm
@@ -27,6 +27,7 @@
 {
     _rootView = [[MockACRView alloc] initWithFrame:CGRectMake(0, 0, 20, 30)];
     std::shared_ptr<ChoiceSetInput> choiceSet = std::make_shared<ChoiceSetInput>();
+    choiceSet->SetPlaceholder("Please choose");
     _acoElem = [[ACOBaseCardElement alloc] initWithBaseCardElement:choiceSet];
 }
 
@@ -45,6 +46,15 @@
     XCTAssertEqualObjects(selectedText, @"Option 1");
     res = [filteredView validate:nil];
     XCTAssertFalse(res);
+}
+
+- (void)testPlaceholderUsesAccessibleColor
+{
+    ACRChoiceSetFilteredStyleView *filteredView = [[ACRChoiceSetFilteredStyleView alloc] initWithInputChoiceSet:_acoElem rootView:_rootView hostConfig:nil searchStateParams:nil typeaheadViewTitle:@"typeahead"];
+    UIColor *placeholderColor = [filteredView.attributedPlaceholder attribute:NSForegroundColorAttributeName atIndex:0 effectiveRange:nil];
+    UIColor *expectedColor = [UIColor colorWithWhite:0.4 alpha:1.0];
+
+    XCTAssertEqualObjects(placeholderColor, expectedColor);
 }
 
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/Helpers/ACRContrastTestUtils.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/Helpers/ACRContrastTestUtils.h
@@ -1,0 +1,38 @@
+#import <UIKit/UIKit.h>
+
+static inline CGFloat ACRLinearizedColorComponent(CGFloat component)
+{
+    return component <= 0.04045 ? component / 12.92 : pow((component + 0.055) / 1.055, 2.4);
+}
+
+static inline CGFloat ACRRelativeLuminance(CGFloat red, CGFloat green, CGFloat blue)
+{
+    return 0.2126 * ACRLinearizedColorComponent(red) +
+           0.7152 * ACRLinearizedColorComponent(green) +
+           0.0722 * ACRLinearizedColorComponent(blue);
+}
+
+static inline CGFloat ACRContrastRatio(UIColor *foregroundColor,
+                                       UIColor *backgroundColor,
+                                       UITraitCollection *traitCollection)
+{
+    CGFloat foregroundRed, foregroundGreen, foregroundBlue, foregroundAlpha;
+    CGFloat backgroundRed, backgroundGreen, backgroundBlue, backgroundAlpha;
+    UIColor *resolvedForeground = [foregroundColor resolvedColorWithTraitCollection:traitCollection];
+    UIColor *resolvedBackground = [backgroundColor resolvedColorWithTraitCollection:traitCollection];
+
+    if (![resolvedForeground getRed:&foregroundRed green:&foregroundGreen blue:&foregroundBlue alpha:&foregroundAlpha] ||
+        ![resolvedBackground getRed:&backgroundRed green:&backgroundGreen blue:&backgroundBlue alpha:&backgroundAlpha]) {
+        return 0;
+    }
+
+    foregroundRed = foregroundRed * foregroundAlpha + backgroundRed * (1 - foregroundAlpha);
+    foregroundGreen = foregroundGreen * foregroundAlpha + backgroundGreen * (1 - foregroundAlpha);
+    foregroundBlue = foregroundBlue * foregroundAlpha + backgroundBlue * (1 - foregroundAlpha);
+
+    CGFloat foregroundLuminance = ACRRelativeLuminance(foregroundRed, foregroundGreen, foregroundBlue);
+    CGFloat backgroundLuminance = ACRRelativeLuminance(backgroundRed, backgroundGreen, backgroundBlue);
+    CGFloat lighter = MAX(foregroundLuminance, backgroundLuminance);
+    CGFloat darker = MIN(foregroundLuminance, backgroundLuminance);
+    return (lighter + 0.05) / (darker + 0.05);
+}

--- a/source/shared/cpp/ObjectModel/HostConfig.h
+++ b/source/shared/cpp/ObjectModel/HostConfig.h
@@ -499,7 +499,7 @@ struct BadgeStylesDefinition
         {
             "#e8ebfa",
             "#e1e1e1",
-            "#5b5fc7"
+            "#444791"
         }
     };
     BadgeStyleDefinition attentionPalette = {
@@ -511,7 +511,7 @@ struct BadgeStylesDefinition
         {
             "#f9d9d9",
             "#e1e1e1",
-            "#d92c2c"
+            "#a4262c"
         }
     };
     BadgeStyleDefinition goodPalette = {
@@ -523,7 +523,7 @@ struct BadgeStylesDefinition
         {
             "#e7f2da",
             "#e1e1e1",
-            "#0f7a0b"
+            "#0b6a0b"
         }
     };
 
@@ -544,12 +544,12 @@ struct BadgeStylesDefinition
         {
             "#f1f1f1",
             "#f1f1f1",
-            "#6e6e6e"
+            "#5f5f5f"
         },
         {
             "#f1f1f1",
             "#e1e1e1",
-            "#6e6e6e"
+            "#5f5f5f"
         }
     };
 


### PR DESCRIPTION
# Description

Luminosity ratio of the placeholder text (Please Choose) is 1.674:1 which is less than 4.5:1.

**Repro Steps:**
1. Launch Adaptive Cards iOS application.
2. Home screen will appear.
3. Activate voice over
4. Navigate to "V1.5" control and select it.
5. Navigate to 'Scenarios' control and activate it.
6. Navigate to 'Restaurant Order' and activate it.
7. Perform right swipe and navigate to the 'Which side would you like?' combo box.
8. Open the tool and check the contrast ratio for the placeholder text and observe the issue.

# Sample Card

```json
{
	"type": "AdaptiveCard",
	"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
	"version": "1.5",
	"body": [
		{
			"type": "TextBlock",
			"text": "Malt & Vine Order Form",
			"size": "large",
			"wrap": true,
			"weight": "bolder",
			"style": "heading"
		},
		{
			"type": "Input.ChoiceSet",
			"id": "EntreeSelectVal",
			"label": "Which entree would you like?",
			"style": "filtered",
			"isRequired": true,
			"errorMessage": "This is a required input",
			"placeholder": "Please choose",
			"choices": [
				{
					"title": "Steak",
					"value": "1"
				},
				{
					"title": "Chicken",
					"value": "2"
				},
				{
					"title": "Tofu",
					"value": "3"
				}
			]
		}
	],
	"actions": [
		{
			"type": "Action.Submit",
			"title": "Place Order"
		}
	]
}
```

# How Verified

**Before**
"Please choose" text
<img width="1128" height="942" alt="image" src="https://github.com/user-attachments/assets/32fd3a28-ebde-4bf6-94be-77b43eec865e" />

Clear text field button
<img width="1139" height="940" alt="image" src="https://github.com/user-attachments/assets/6310aed8-b005-48ba-81ba-55e1a3b06c8a" />

"Accent Tint" text
<img width="1182" height="951" alt="image" src="https://github.com/user-attachments/assets/02c90948-43eb-472f-ac57-36c719049649" />

"Attention Tint" text
<img width="1192" height="965" alt="image" src="https://github.com/user-attachments/assets/40ec817e-edbe-4820-aa5f-fdda5ec9d8d2" />

"Subtle Filled" and "Subtle Tint" text
<img width="1148" height="935" alt="image" src="https://github.com/user-attachments/assets/a532ceec-311a-479f-9147-d6e854d555b1" />


**After**
"Please choose" text
<img width="1139" height="958" alt="Avalable Samole SONS" src="https://github.com/user-attachments/assets/ff351c2a-9d09-4838-80eb-12ca3d02ba7e" />

Clear text field button (passes WCAG requirement of at least 3:1 contrast for non-text graphical control)
<img width="1149" height="953" alt="image" src="https://github.com/user-attachments/assets/0e931020-19d6-4d6a-b725-4f0967c5e71a" />

"Accent Tint" text
<img width="1164" height="948" alt="image" src="https://github.com/user-attachments/assets/c073e433-5a93-415d-bbbe-1a8c34a011da" />

"Attention Tint" text
<img width="1155" height="945" alt="image" src="https://github.com/user-attachments/assets/0ed3bf94-9fb2-47fd-afc8-2ee0c233cde5" />

"Subtle Filled" and "Subtle Tint" text
<img width="1151" height="945" alt="image" src="https://github.com/user-attachments/assets/33a5999c-3c7a-4a9e-b5a5-33558739280b" />