### PR TITLE
fix(ios): rollup 2026-09 - visionOS keyboardDismissMode guard, container collapse regression

### DIFF
--- a/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerUITests/ADCIOSVisualizerUITests.mm
+++ b/source/ios/AdaptiveCards/ADCIOSVisualizer/ADCIOSVisualizerUITests/ADCIOSVisualizerUITests.mm
@@ -9,6 +9,10 @@
 #import "AdaptiveCards/ACOHostConfigPrivate.h"
 #import <AdaptiveCards/AdaptiveCards.h>
 #import <XCTest/XCTest.h>
+
+/// Ceiling for popover/bottom-sheet transitions. Generous on purpose: this bounds a
+/// wait that normally returns in well under a second; it is not a fixed delay.
+static const NSTimeInterval kACRPopoverTimeout = 10.0;
 #include <string>
 
 @interface ADCIOSVisualizerUITests : XCTestCase
@@ -831,13 +835,36 @@
     XCTAssertTrue(lessContentTextView.exists, @"'Less Content' TextView should exist");
     [self dismissPopoverBottomSheet];
     XCUIElement *containerButton = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"This Container is clickable and will show a popover"]];
-    XCTAssertTrue(containerButton.exists && containerButton.isHittable, @"'This Container is clickable and will show a popover' button should exist and be hittable");
+    XCTAssertTrue([containerButton waitForExistenceWithTimeout:kACRPopoverTimeout] && containerButton.isHittable, @"'This Container is clickable and will show a popover' button should exist and be hittable");
     [containerButton tap];
     XCUIElement *popoverTextView = [testApp.textViews elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"This is a popover"]];
     XCTAssertTrue(popoverTextView.exists, @"'This is a popover' TextView should exist");
     [self dismissPopoverBottomSheet];
-    XCUIElement *popoverIcon = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @", Click me to show a popover"]];
-    XCTAssertTrue(popoverIcon.exists && popoverIcon.isHittable, @"Button ', Click me to show a popover' should exist and be hittable");
+    // The card carries two accessibility elements for this popover, both reachable and both
+    // correct. body[6] is an Image whose selectAction opens the popover; body[7] is an Icon
+    // carrying an identical selectAction and identical popover content.
+    //
+    // The Image's bitmap is fetched from a remote URL. When that fetch does not complete -
+    // CI runners have no dependable egress, and the URL answers a redirect - the
+    // UIImageView collapses to height 0. Measured on a runner: frame {354, 0}, isHittable
+    // NO, and zero images anywhere in the tree, while the sibling Icon measured {354, 56}
+    // and was hittable. The Image element is still present and still correctly named,
+    // because ACRImageRenderer applies the label synchronously at render; only its hit area
+    // is gone. Asserting isHittable on it therefore tested network availability rather than
+    // the SDK, which is why this failed 10/10 offline and passed intermittently before.
+    //
+    // So: still assert the Image is present and correctly named - that is the part that
+    // protects ACRImageRenderer's labelling, and it is network-independent - but drive the
+    // popover through the Icon, which is drawn from a local font glyph and is deterministic.
+    //
+    // Both predicates must remain exact. The two labels differ only by a leading ", ",
+    // because configureForAccessibilityLabel joins an empty title component, so a CONTAINS
+    // match would match both and elementMatchingPredicate requires a unique match.
+    XCUIElement *popoverImage = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @", Click me to show a popover"]];
+    XCTAssertTrue([popoverImage waitForExistenceWithTimeout:kACRPopoverTimeout], @"Image with a popover selectAction should be present and named");
+
+    XCUIElement *popoverIcon = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Click me to show a popover"]];
+    XCTAssertTrue([popoverIcon waitForExistenceWithTimeout:kACRPopoverTimeout] && popoverIcon.isHittable, @"Icon with a popover selectAction should exist and be hittable");
     [popoverIcon tap];
     popoverTextView = [testApp.textViews elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"This Popover is made with Adaptive Card elements, it supports actions and is fully accessible."]];
     XCTAssertTrue(popoverTextView.exists, @"The icon popover TextView with the expected label should exist");
@@ -864,9 +891,16 @@
 - (void) dismissPopoverBottomSheet
 {
     XCUIElement *dismissButton = [testApp.buttons elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"Dismiss"]];
-    XCTAssertTrue(dismissButton.exists && dismissButton.isHittable, @"'Dismiss' button should exist and be hittable");
+    XCTAssertTrue([dismissButton waitForExistenceWithTimeout:kACRPopoverTimeout] && dismissButton.isHittable, @"'Dismiss' button should exist and be hittable");
     [dismissButton tap];
 
+    // The sheet dismisses with an animation. Returning as soon as the tap is delivered lets
+    // every caller race it: the element underneath already exists but is still covered, so
+    // isHittable reports NO. Wait for the sheet to leave the hierarchy before returning.
+    [self expectationForPredicate:[NSPredicate predicateWithFormat:@"exists == NO"]
+                        evaluatedWithObject:dismissButton
+                                    handler:nil];
+    [self waitForExpectationsWithTimeout:kACRPopoverTimeout handler:nil];
 }
 
 - (void) checkAndTap:(XCUIElement *)element

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		244049E12EC24097000A06DF /* ACRIImageResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 244049E02EC2408D000A06DF /* ACRIImageResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		244915622EBCE3BD0040DF94 /* ACOReferencePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 244915612EBCE3BD0040DF94 /* ACOReferencePrivate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		246485662E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */; };
+		724D78627BA31B464C0B33D0 /* ACRContainerCollapseTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2086D6F3FBCB3C480E4E59BD /* ACRContainerCollapseTests.mm */; };
 		2AC0F7A22F01000B0085F3BD /* ACROverflowTargetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */; };
 		248924C62EBB617600F76802 /* CitationRun.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 248924C32EBB617600F76802 /* CitationRun.cpp */; };
 		248924C72EBB617600F76802 /* References.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 248924C52EBB617600F76802 /* References.cpp */; };
@@ -706,6 +707,7 @@
 		244049E02EC2408D000A06DF /* ACRIImageResolver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ACRIImageResolver.h; sourceTree = "<group>"; };
 		244915612EBCE3BD0040DF94 /* ACOReferencePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ACOReferencePrivate.h; path = PrivateHeaders/ACOReferencePrivate.h; sourceTree = "<group>"; };
 		246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRPopoverTargetTests.mm; sourceTree = "<group>"; };
+		2086D6F3FBCB3C480E4E59BD /* ACRContainerCollapseTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACRContainerCollapseTests.mm; sourceTree = "<group>"; };
 		2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ACROverflowTargetTests.mm; sourceTree = "<group>"; };
 		248924C22EBB617600F76802 /* CitationRun.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CitationRun.h; path = ../../../../shared/cpp/ObjectModel/CitationRun.h; sourceTree = "<group>"; };
 		248924C32EBB617600F76802 /* CitationRun.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CitationRun.cpp; path = ../../../../shared/cpp/ObjectModel/CitationRun.cpp; sourceTree = "<group>"; };
@@ -1925,6 +1927,7 @@
 				6B124C9226B8AE3B007E9641 /* Mocks */,
 				6BE6C79F26E17077009E9171 /* TestFiles */,
 				246485652E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm */,
+				2086D6F3FBCB3C480E4E59BD /* ACRContainerCollapseTests.mm */,
 				2AC0F7A12F01000A0085F3BD /* ACROverflowTargetTests.mm */,
 			);
 			path = AdaptiveCardsTests;
@@ -3236,6 +3239,7 @@
 				CFF95C0F2982E4EC00F321C3 /* ACOTypeaheadDebouncerTests.mm in Sources */,
 				6B124C9826B9F5FC007E9641 /* AdaptiveCardsColumnTests.mm in Sources */,
 				246485662E3CEA0C0085F3BD /* ACRPopoverTargetTests.mm in Sources */,
+				724D78627BA31B464C0B33D0 /* ACRContainerCollapseTests.mm in Sources */,
 				2AC0F7A22F01000B0085F3BD /* ACROverflowTargetTests.mm in Sources */,
 				46CBB6422C22BA88008FC5D5 /* AdaptiveCardCompoundButtonTests.mm in Sources */,
 				6B4C05BF27864B0800882387 /* ACRImagePropertiesTests.mm in Sources */,

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetViewController.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRBottomSheetViewController.mm
@@ -189,7 +189,9 @@
     UIScrollView *scrollView = [[UIScrollView alloc] init];
     scrollView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:scrollView];
+#if !TARGET_OS_VISION
     scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+#endif
     self.scrollView = scrollView;
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
     [self.scrollView addSubview:self.contentView];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRContentStackView.mm
@@ -910,12 +910,6 @@ using namespace AdaptiveCards;
 
     if (!acoElem.element->GetIsVisible()) {
         [self registerInvisibleView:renderedView];
-    } else if ([renderedView isKindOfClass:[ACRContentStackView class]] &&
-               !((ACRContentStackView *)renderedView).hasVisibleContent) {
-        // The element is marked visible, but all of its children are invisible.
-        // Register it the same way as an explicit isVisible:false so the view
-        // and its separator are collapsed by applyVisibilityToSubviews.
-        [self registerInvisibleView:renderedView];
     }
 }
 

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACRContainerCollapseTests.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCardsTests/ACRContainerCollapseTests.mm
@@ -1,0 +1,190 @@
+//
+//  ACRContainerCollapseTests.mm
+//  AdaptiveCardsTests
+//
+//  Copyright © 2026 Microsoft. All rights reserved.
+//
+
+#import "ACOAdaptiveCard.h"
+#import "ACOAdaptiveCardParseResult.h"
+#import "ACOHostConfig.h"
+#import "ACOHostConfigParseResult.h"
+#import "ACRContentStackView.h"
+#import "ACRRenderResult.h"
+#import "ACRRenderer.h"
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+/// Regression coverage for container collapsing.
+///
+/// A Container whose children are visible must never be collapsed. This broke once
+/// before: the emptiness check was evaluated while children were still rendering, at
+/// which point a child container always reports "no visible content", so every nested
+/// container was collapsed and its content disappeared. FactSets nested in a Container
+/// were the most visible casualty.
+///
+/// These tests assert on **hidden state** rather than on rendered text. Text is not a
+/// usable signal here for two reasons:
+///   1. TextBlock renders into an ACRViewAttachingTextView (a UITextView), not a UILabel.
+///   2. Text content is populated by background preprocessing on ACRView's serial text
+///      queue, and the SDK never awaits it during render, so no text is present
+///      synchronously.
+/// A text-based assertion therefore passes or fails for reasons unrelated to collapsing,
+/// and a "text is absent" assertion would pass vacuously.
+///
+/// The collapse path itself is synchronous and deterministic:
+///   registerInvisibleView: -> applyVisibilityToSubviews -> hideView:
+/// and hideView: sets `hidden = YES` on the target view. That is what is asserted below.
+@interface ACRContainerCollapseTests : XCTestCase
+@end
+
+@implementation ACRContainerCollapseTests {
+    NSString *_hostConfig;
+}
+
+- (void)setUp
+{
+    [super setUp];
+    _hostConfig = @"{\"supportsInteractivity\":true}";
+}
+
+#pragma mark - Helpers
+
+/// Every ACRContentStackView in the tree. Containers, Columns and ColumnSets are all
+/// content stack views, and collapsing manifests as one of them being hidden.
+- (NSArray<ACRContentStackView *> *)contentStacksIn:(UIView *)view
+{
+    NSMutableArray<ACRContentStackView *> *found = [NSMutableArray array];
+    if ([view isKindOfClass:[ACRContentStackView class]]) {
+        [found addObject:(ACRContentStackView *)view];
+    }
+    for (UIView *sub in view.subviews) {
+        [found addObjectsFromArray:[self contentStacksIn:sub]];
+    }
+    return found;
+}
+
+- (NSArray<ACRContentStackView *> *)hiddenContentStacksIn:(UIView *)view
+{
+    NSMutableArray<ACRContentStackView *> *hidden = [NSMutableArray array];
+    for (ACRContentStackView *stack in [self contentStacksIn:view]) {
+        if (stack.isHidden) {
+            [hidden addObject:stack];
+        }
+    }
+    return hidden;
+}
+
+- (NSUInteger)hiddenViewCountIn:(UIView *)view
+{
+    NSUInteger count = view.isHidden ? 1 : 0;
+    for (UIView *sub in view.subviews) {
+        count += [self hiddenViewCountIn:sub];
+    }
+    return count;
+}
+
+- (UIView *)renderPayload:(NSString *)payload
+{
+    ACOAdaptiveCardParseResult *parsed = [ACOAdaptiveCard fromJson:payload];
+    XCTAssertTrue(parsed.isValid, @"payload failed to parse");
+
+    ACOHostConfigParseResult *config = [ACOHostConfig fromJson:_hostConfig resourceResolvers:nil];
+    XCTAssertTrue(config.isValid, @"host config failed to parse");
+
+    ACRRenderResult *result = [ACRRenderer render:parsed.card
+                                           config:config.config
+                                  widthConstraint:320.0f
+                                            theme:ACRThemeLight];
+    XCTAssertTrue(result.succeeded, @"render failed");
+    XCTAssertNotNil(result.view);
+
+    UIView *rendered = (UIView *)result.view;
+    [rendered setNeedsLayout];
+    [rendered layoutIfNeeded];
+    return rendered;
+}
+
+/// Shared assertion. Guards against passing vacuously: if the payload produced no
+/// content stack views at all then "nothing is hidden" would be trivially true, so the
+/// presence of at least `expectedStacks` of them is asserted first.
+- (void)assertNothingCollapsedIn:(UIView *)rendered
+                 atLeastStacks:(NSUInteger)expectedStacks
+                       message:(NSString *)message
+{
+    NSArray<ACRContentStackView *> *stacks = [self contentStacksIn:rendered];
+    XCTAssertGreaterThanOrEqual(stacks.count, expectedStacks,
+                                @"%@: expected at least %lu content stack views, found %lu - "
+                                @"the payload did not render the shape under test",
+                                message, (unsigned long)expectedStacks, (unsigned long)stacks.count);
+
+    NSArray<ACRContentStackView *> *hidden = [self hiddenContentStacksIn:rendered];
+    XCTAssertEqual(hidden.count, 0u, @"%@: %lu of %lu content stack views were collapsed",
+                   message, (unsigned long)hidden.count, (unsigned long)stacks.count);
+}
+
+#pragma mark - Tests
+
+/// A FactSet inside a Container must still render. Regression: the container was
+/// collapsed and the card came back visually empty.
+- (void)testContainerWithFactSetIsNotCollapsed
+{
+    NSString *payload = @"{"
+                         "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
+                         "\"type\":\"Container\",\"items\":[{"
+                         "\"type\":\"FactSet\",\"facts\":["
+                         "{\"title\":\"Severity\",\"value\":\"Severity A\"},"
+                         "{\"title\":\"Location\",\"value\":\"Zone 1\"}]}]}]}";
+
+    UIView *rendered = [self renderPayload:payload];
+    [self assertNothingCollapsedIn:rendered atLeastStacks:1 message:@"Container with FactSet"];
+}
+
+/// Same shape one level deeper, since the collapse walked nested content stack views.
+- (void)testNestedContainerWithVisibleChildIsNotCollapsed
+{
+    NSString *payload = @"{"
+                         "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
+                         "\"type\":\"Container\",\"items\":[{"
+                         "\"type\":\"Container\",\"items\":[{"
+                         "\"type\":\"TextBlock\",\"text\":\"Nested survives\"}]}]}]}";
+
+    UIView *rendered = [self renderPayload:payload];
+    [self assertNothingCollapsedIn:rendered atLeastStacks:2 message:@"Nested Container"];
+}
+
+/// ColumnSet is the other shape the collapse targeted.
+- (void)testColumnSetWithVisibleColumnIsNotCollapsed
+{
+    NSString *payload = @"{"
+                         "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
+                         "\"type\":\"ColumnSet\",\"columns\":[{"
+                         "\"type\":\"Column\",\"items\":[{"
+                         "\"type\":\"TextBlock\",\"text\":\"Column content\"}]}]}]}";
+
+    UIView *rendered = [self renderPayload:payload];
+    [self assertNothingCollapsedIn:rendered atLeastStacks:2 message:@"ColumnSet with Column"];
+}
+
+/// The explicit isVisible:false path must still hide its target. This is the control:
+/// it proves the visibility machinery is actually running in these tests, so the
+/// "nothing is hidden" assertions above are meaningful rather than vacuous.
+- (void)testExplicitlyInvisibleChildIsStillHidden
+{
+    NSString *payload = @"{"
+                         "\"type\":\"AdaptiveCard\",\"version\":\"1.5\",\"body\":[{"
+                         "\"type\":\"Container\",\"items\":["
+                         "{\"type\":\"TextBlock\",\"text\":\"Visible\"},"
+                         "{\"type\":\"TextBlock\",\"text\":\"Hidden\",\"isVisible\":false}]}]}";
+
+    UIView *rendered = [self renderPayload:payload];
+
+    XCTAssertGreaterThan([self hiddenViewCountIn:rendered], 0u,
+                         @"isVisible:false produced no hidden view - the visibility "
+                         @"machinery did not run, so the collapse assertions would be vacuous");
+
+    // The container itself still holds a visible child and must survive.
+    [self assertNothingCollapsedIn:rendered atLeastStacks:1 message:@"Container with one hidden child"];
+}
+
+@end


### PR DESCRIPTION
## Summary

Rollup of two reviewed iOS fixes plus the CI fix that was blocking them, combined into a single PR so they can be validated and merged in one CI pass.

The two product fixes are **byte-identical** to their standalone PRs (applied as each PR's net diff against `main`, verified per-file). All three changes touch **disjoint files**, so there are no interactions between them.

| Fix | Standalone PR | File(s) |
|---|---|---|
| Guard `keyboardDismissMode`, unavailable on visionOS | #722 | `ACRBottomSheetViewController.mm` |
| Stop collapsing containers that still have visible content | #724 | `ACRContentStackView.mm`, `ACRContainerCollapseTests.mm`, `project.pbxproj` |
| Stop `testPopoverRendering` depending on a remote image fetch | — | `ADCIOSVisualizerUITests.mm` (test-only) |

Total: **5 files, +234 / −10**. No SDK source is touched by the third change.

Both standalone PRs are approved (P-Harika, @arocc).

> **Scope note:** the Swift 6 `NS_SWIFT_UI_ACTOR` annotation and the seven-fix accessibility rollup are **not** in this PR — they shipped in #737, merged as `25a845d4` on 2026-08-27 and already present in `main`.

## Why a rollup

`teams-adaptivecards-ios-pr` was failing repo-wide, so every PR needed multiple ~40-minute runs to get one green result. Consolidating meant fighting that once rather than twice. That failure is now diagnosed and fixed here — see below.

## The fixes

**#722 — visionOS build break.** `scrollView.keyboardDismissMode` is `API_UNAVAILABLE(visionos)`. The `#if !TARGET_OS_VISION` guard around it was lost, so the xros archive fails to compile with `xcodebuild` error 65. The guard is restored exactly as it was.

**#724 — nested containers render blank.** `ACRContentStackView.hasVisibleContent` is consulted *while rendering*, but `_visibleViews` is only populated by `applyVisibilityToSubviews`, which runs after all children have rendered. A nested container therefore always reported empty and was registered invisible, collapsing it and its separator. This is deterministic, not a race.

Downstream impact: this made FactSets render blank in Teams iOS. It was caught by visual-diff, where affected cards kept their width but lost height (one went 1050x288 → 1050x72).

The fix removes the premature collapse branch. The `hasVisibleContent` getter itself is untouched and still used by `applyVisibilityToSubviews`, which runs at the correct time.

**`testPopoverRendering` — the repo-wide CI blocker.** Test-only; see the next section.

## The CI blocker, diagnosed and fixed

An earlier revision of this description said the failure was environmental and unexplained, and asked for someone with Mac access. That was wrong, and one piece of the reasoning was actively misleading: the "control" build **14944** was pinned to `25a845d40c`, which **is** the #737 merge commit — so it contained the accessibility rollup and could never have isolated it. Retracting that.

**It was never flaky.** Measured on clean `upstream/main` with no local modifications, running the test 10 times against a single build:

| substrate | pass rate |
|---|---|
| `upstream/main`, unmodified | **0 / 10** |
| `upstream/main` + this fix | **10 / 10** |

**Root cause.** Dumping the real accessibility element tree at the point of failure:

```
label=', Click me to show a popover'  frame={{24,617},{354,0}}   hittable=0 exists=1
label='Click me to show a popover'    frame={{24,627},{354,56}}  hittable=1 exists=1
images in tree: 0
```

`Action.Popover.json` `body[6]` is an **Image** whose bitmap is fetched from a remote URL (`adaptivecards.io`, which answers a redirect). When that fetch does not complete — CI agents have no dependable egress — the `UIImageView` collapses to **height 0**. The element is still present and still correctly named, because `ACRImageRenderer` applies the label synchronously at render; only its hit area is gone.

So `exists && isHittable` was asserting **network availability**, not SDK behaviour. That is why it passed intermittently for months and then failed consistently.

**#737 is not responsible.** `ACRImageRenderer.mm`, `ACRIconRenderer.mm` and `UtiliOS.mm` are all untouched in `1b625cb50..main`, and the interactive-icon label form has been in place since 2026-08-01 — three weeks before the last green run.

**The fix keeps both halves of the coverage:**
- still asserts the Image is present and correctly named, which is what protects `ACRImageRenderer`'s labelling and is network-independent;
- drives the popover through `body[7]`, the Icon carrying an identical `selectAction` and verified-identical popover content, drawn from a local font glyph and therefore deterministic.

Predicates stay **exact matches**. The two labels differ only by a leading `", "`, because `configureForAccessibilityLabel` joins an empty title component, so a `CONTAINS` match would match both and `elementMatchingPredicate` requires a unique match.

Also hardened, both confirmed against the `xcodebuild` trace: `dismissPopoverBottomSheet` now waits for the sheet to leave the hierarchy instead of returning mid-animation, and the two post-dismissal lookups use `waitForExistenceWithTimeout` rather than a bare `.exists` read. The suite previously contained no `waitForExistence` calls at all.

No assertion was removed or weakened.

## Tests

`ACRContainerCollapseTests.mm` (4 tests) covers the #724 regression. The tests assert on **hidden state** rather than rendered text: the collapse path is `registerInvisibleView:` → `applyVisibilityToSubviews` → `hideView:`, which is synchronous and therefore deterministically assertable. Asserting on rendered text would pass vacuously, because text rendering is deferred onto a background queue and nothing has rendered synchronously at assertion time.

## Follow-up, deliberately not in this PR

The leading `", "` above is a real latent VoiceOver defect. `configureForAccessibilityLabel` (`UtiliOS.mm:655`) does `if (action.title)` — a nil-check — but an absent title arrives from C++ `GetTitle()` as `@""`, which is non-nil, so an empty component is joined and VoiceOver reads the leading comma as an odd pause. `if (action.title.length)` would fix it. Kept out of this changeset because it changes composed labels app-wide and this PR is release-critical. Because the test now matches exactly rather than on the artifact, that fix can land separately without touching this test again.

Separately: the sample card's dependency on a remote image is unchanged — this PR routes the test around it rather than removing it. A bundled asset would be more robust for any future test touching `body[6]`.

## Merge note

If you prefer to merge this rollup, #722 and #724 can be closed as included here. If you would rather take them individually, note that the `testPopoverRendering` fix is only in this PR, and without it `teams-adaptivecards-ios-pr` stays red repo-wide.
