### PR TITLE
[iOS] Version upgrade to 2.12.1.

### DIFF
--- a/source/ios/tools/AdaptiveCards.podspec
+++ b/source/ios/tools/AdaptiveCards.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name             = 'AdaptiveCards'
 
-  spec.version          = '2.12.0'
+  spec.version          = '2.12.1'
 
   spec.license          = { :type => 'Adaptive Cards Binary EULA', :file => 'source/EULA-Non-Windows.txt' } 
 
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 
   spec.summary          = 'Adaptive Cards are a new way for developers to exchange card content in a common and consistent way'
   
-  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.12.0' }
+  spec.source       = { :git => 'https://github.com/microsoft/AdaptiveCards-Mobile.git', :tag => 'iOS/adaptivecards-ios@2.12.1' }
 
   spec.default_subspecs = 'AdaptiveCardsCore', 'AdaptiveCardsPrivate', 'ObjectModel', 'UIProviders'
 


### PR DESCRIPTION
## Summary

Bumps the iOS podspec to **2.12.1**, following the same shape as #719 (the 2.12.0 bump): `spec.version` and the `spec.source` tag move together, one file, +2/-2.

`AdaptiveCards.podspec` at the repo root is a symlink to `source/ios/tools/AdaptiveCards.podspec`, so it picks the change up automatically and is intentionally not touched.

## What ships in 2.12.1

Everything merged to `main` since the `iOS/adaptivecards-ios@2.12.0` tag:

| PR | Change |
|---|---|
| #738 | Luminosity/contrast fix - placeholder text was 1.674:1 against a 4.5:1 requirement. Teams light + dark HostConfig, `ACRTextField`, ChoiceSet views, shared `HostConfig.h` |
| #737 | Accessibility rollup - CompoundButton, rating stars, ChoiceSet name, main-actor isolation, overflow focus, inline action name, `labelFor` link text |
| #739 | visionOS `keyboardDismissMode` guard, container-collapse regression, `testPopoverRendering` determinism |
| #730 | LTR semantic content attribute |
| #723 | Thread-safe text data for the FactSet renderer |
| #728, #720 | Release pipeline fixes |

## Why now

Two of these are blocking Teams iOS, which is pinned at 2.12.0 and carrying local patches for them:

- **visionOS** (#722, in #739): `scrollView.keyboardDismissMode` is `API_UNAVAILABLE(visionos)`. Without the guard the xros archive fails to compile with `xcodebuild` error 65.
- **Container collapse** (#724, in #739): nested containers were collapsed while still holding visible content, because `hasVisibleContent` is consulted during rendering but `_visibleViews` is not populated until `applyVisibilityToSubviews` runs. This rendered FactSets blank in Teams iOS.

Once 2.12.1 is on trunk, Teams iOS can drop three local patches: `04_visionos_keyboard_dismiss`, `05_remove_cascading_hide`, and `06_main_actor_card_element_renderer` (already fixed on `main` by #737, just never shipped).

## After merge

1. Tag `iOS/adaptivecards-ios@2.12.1` on the merge commit and cut the GitHub release.
2. Publish to CocoaPods trunk.
